### PR TITLE
[19.0][FIX] base_tier_validation: auto-promote first review to pending

### DIFF
--- a/base_tier_validation/README.rst
+++ b/base_tier_validation/README.rst
@@ -125,6 +125,22 @@ improvement will be very valuable.
 Changelog
 =========
 
+19.0.1.0.1 (2026-05-12)
+-----------------------
+
+Fixes:
+
+- Restore auto-promotion of the lowest-sequence review to ``pending``
+  immediately after ``request_validation`` so the workflow can move
+  forward without an external trigger. The 19.0 migration had moved this
+  side-effect out of ``_compute_can_review`` into a separate
+  ``_update_review_status`` that was only invoked when the requester was
+  themself the first reviewer or when ``notify_on_create`` was set,
+  leaving reviews stuck in ``waiting`` in every other case.
+- Coerce ``next_review`` to ``False`` when no review is pending, so the
+  "needs to be validated" banner no longer leaks the empty
+  ``tier.review()`` recordset repr into its ``Char`` field.
+
 17.0.1.0.0 (2024-01-10)
 -----------------------
 

--- a/base_tier_validation/README.rst
+++ b/base_tier_validation/README.rst
@@ -140,6 +140,13 @@ Fixes:
 - Coerce ``next_review`` to ``False`` when no review is pending, so the
   "needs to be validated" banner no longer leaks the empty
   ``tier.review()`` recordset repr into its ``Char`` field.
+- Fix ``_notify_review_available`` so the reviewer reached by
+  ``notify_on_pending`` is actually delivered the message. The
+  tier-validation subtypes have ``default=False`` so a plain
+  ``message_subscribe(partner_ids=...)`` left the reviewer subscribed
+  only to default subtypes; ``message_post`` with the
+  ``mt_tier_validation_requested`` subtype then routed to nobody. Pass
+  ``subtype_ids`` explicitly (mirroring ``_notify_review_requested``).
 
 17.0.1.0.0 (2024-01-10)
 -----------------------

--- a/base_tier_validation/__manifest__.py
+++ b/base_tier_validation/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Base Tier Validation",
     "summary": "Implement a validation process based on tiers.",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "development_status": "Mature",
     "maintainers": ["LoisRForgeFlow"],
     "category": "Tools",

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -238,9 +238,7 @@ class TierValidation(models.AbstractModel):
             review = rec.review_ids.sorted("sequence").filtered(
                 lambda x: x.status == "pending"
             )[:1]
-            rec.next_review = (
-                self.env._("Next: %s", review.name) if review else False
-            )
+            rec.next_review = self.env._("Next: %s", review.name) if review else False
 
     def _compute_hide_reviews(self):
         for rec in self:

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -944,9 +944,18 @@ class TierValidation(models.AbstractModel):
                     lambda r, x=rec: r.definition_id.notify_on_pending
                     and r.res_id == x.id
                 ).mapped("reviewer_ids")
-                # Subscribe reviewers and notify
+                # Subscribe reviewers to the tier-validation-requested
+                # subtype explicitly, otherwise ``message_post`` below would
+                # route to no one (the subtype is ``default=False``). Only
+                # post the message when at least one reviewer wants to be
+                # notified -- mirroring ``_notify_review_requested``.
+                if not users_to_notify:
+                    continue
                 rec.message_subscribe(
-                    partner_ids=users_to_notify.mapped("partner_id").ids
+                    partner_ids=users_to_notify.mapped("partner_id").ids,
+                    subtype_ids=self.env.ref(
+                        self._get_requested_notification_subtype()
+                    ).ids,
                 )
                 rec.message_post(
                     subtype_xmlid=self._get_requested_notification_subtype(),

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -238,7 +238,9 @@ class TierValidation(models.AbstractModel):
             review = rec.review_ids.sorted("sequence").filtered(
                 lambda x: x.status == "pending"
             )[:1]
-            rec.next_review = review and self.env._("Next: %s", review.name or "")
+            rec.next_review = (
+                self.env._("Next: %s", review.name) if review else False
+            )
 
     def _compute_hide_reviews(self):
         for rec in self:
@@ -788,16 +790,15 @@ class TierValidation(models.AbstractModel):
                         sequence += 1
                         vals_list.append(rec._prepare_tier_review_vals(td, sequence))
         created_trs = tr_obj.create(vals_list)
-        review_counter = any(self.mapped("can_review"))
-        if review_counter:
+        # ``request_validation`` creates all reviews as ``waiting``. Promote the
+        # available one(s) to ``pending`` immediately so the workflow can move
+        # forward without an external trigger. Without this, when the user
+        # asking for validation is not themself the first reviewer (and no
+        # ``notify_on_create`` definition is present), reviews would stay in
+        # ``waiting`` indefinitely and no reviewer would be notified.
+        created_trs._update_review_status()
+        if any(self.mapped("can_review")):
             self._update_counter({"review_created": True})
-        # ``request_validation`` creates all reviews as ``waiting``.
-        # If the counter update have not already updated the actionable review status,
-        # do it before notifying reviewers about creation.
-        if not review_counter and created_trs.filtered(
-            "definition_id.notify_on_create"
-        ):
-            created_trs._update_review_status()
         self._notify_review_requested(created_trs)
         return created_trs
 

--- a/base_tier_validation/readme/HISTORY.md
+++ b/base_tier_validation/readme/HISTORY.md
@@ -12,6 +12,13 @@ Fixes:
 - Coerce ``next_review`` to ``False`` when no review is pending, so
   the "needs to be validated" banner no longer leaks the empty
   ``tier.review()`` recordset repr into its ``Char`` field.
+- Fix ``_notify_review_available`` so the reviewer reached by
+  ``notify_on_pending`` is actually delivered the message. The
+  tier-validation subtypes have ``default=False`` so a plain
+  ``message_subscribe(partner_ids=...)`` left the reviewer subscribed
+  only to default subtypes; ``message_post`` with the
+  ``mt_tier_validation_requested`` subtype then routed to nobody. Pass
+  ``subtype_ids`` explicitly (mirroring ``_notify_review_requested``).
 
 ## 17.0.1.0.0 (2024-01-10)
 

--- a/base_tier_validation/readme/HISTORY.md
+++ b/base_tier_validation/readme/HISTORY.md
@@ -1,3 +1,18 @@
+## 19.0.1.0.1 (2026-05-12)
+
+Fixes:
+
+- Restore auto-promotion of the lowest-sequence review to ``pending``
+  immediately after ``request_validation`` so the workflow can move
+  forward without an external trigger. The 19.0 migration had moved
+  this side-effect out of ``_compute_can_review`` into a separate
+  ``_update_review_status`` that was only invoked when the requester
+  was themself the first reviewer or when ``notify_on_create`` was
+  set, leaving reviews stuck in ``waiting`` in every other case.
+- Coerce ``next_review`` to ``False`` when no review is pending, so
+  the "needs to be validated" banner no longer leaks the empty
+  ``tier.review()`` recordset repr into its ``Char`` field.
+
 ## 17.0.1.0.0 (2024-01-10)
 
 Migrated to Odoo 17.

--- a/base_tier_validation/static/description/index.html
+++ b/base_tier_validation/static/description/index.html
@@ -398,29 +398,30 @@ compute method in <tt class="docutils literal">_get_after_validation_exceptions<
 <li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
 <li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-2">Known issues / Roadmap</a></li>
 <li><a class="reference internal" href="#changelog" id="toc-entry-3">Changelog</a><ul>
-<li><a class="reference internal" href="#section-1" id="toc-entry-4">17.0.1.0.0 (2024-01-10)</a></li>
-<li><a class="reference internal" href="#section-2" id="toc-entry-5">14.0.1.0.0 (2020-11-19)</a></li>
-<li><a class="reference internal" href="#section-3" id="toc-entry-6">13.0.1.2.2 (2020-08-30)</a></li>
-<li><a class="reference internal" href="#section-4" id="toc-entry-7">12.0.3.3.1 (2019-12-02)</a></li>
-<li><a class="reference internal" href="#section-5" id="toc-entry-8">12.0.3.3.0 (2019-11-27)</a></li>
-<li><a class="reference internal" href="#section-6" id="toc-entry-9">12.0.3.2.1 (2019-11-26)</a></li>
-<li><a class="reference internal" href="#section-7" id="toc-entry-10">12.0.3.2.0 (2019-11-25)</a></li>
-<li><a class="reference internal" href="#section-8" id="toc-entry-11">12.0.3.1.0 (2019-07-08)</a></li>
-<li><a class="reference internal" href="#section-9" id="toc-entry-12">12.0.3.0.0 (2019-12-02)</a></li>
-<li><a class="reference internal" href="#section-10" id="toc-entry-13">12.0.2.1.0 (2019-05-29)</a></li>
-<li><a class="reference internal" href="#section-11" id="toc-entry-14">12.0.2.0.0 (2019-05-28)</a></li>
-<li><a class="reference internal" href="#section-12" id="toc-entry-15">12.0.1.0.0 (2019-02-18)</a></li>
-<li><a class="reference internal" href="#section-13" id="toc-entry-16">11.0.1.0.0 (2018-05-09)</a></li>
-<li><a class="reference internal" href="#section-14" id="toc-entry-17">10.0.1.0.0 (2018-03-26)</a></li>
-<li><a class="reference internal" href="#section-15" id="toc-entry-18">9.0.1.0.0 (2017-12-02)</a></li>
+<li><a class="reference internal" href="#section-1" id="toc-entry-4">19.0.1.0.1 (2026-05-12)</a></li>
+<li><a class="reference internal" href="#section-2" id="toc-entry-5">17.0.1.0.0 (2024-01-10)</a></li>
+<li><a class="reference internal" href="#section-3" id="toc-entry-6">14.0.1.0.0 (2020-11-19)</a></li>
+<li><a class="reference internal" href="#section-4" id="toc-entry-7">13.0.1.2.2 (2020-08-30)</a></li>
+<li><a class="reference internal" href="#section-5" id="toc-entry-8">12.0.3.3.1 (2019-12-02)</a></li>
+<li><a class="reference internal" href="#section-6" id="toc-entry-9">12.0.3.3.0 (2019-11-27)</a></li>
+<li><a class="reference internal" href="#section-7" id="toc-entry-10">12.0.3.2.1 (2019-11-26)</a></li>
+<li><a class="reference internal" href="#section-8" id="toc-entry-11">12.0.3.2.0 (2019-11-25)</a></li>
+<li><a class="reference internal" href="#section-9" id="toc-entry-12">12.0.3.1.0 (2019-07-08)</a></li>
+<li><a class="reference internal" href="#section-10" id="toc-entry-13">12.0.3.0.0 (2019-12-02)</a></li>
+<li><a class="reference internal" href="#section-11" id="toc-entry-14">12.0.2.1.0 (2019-05-29)</a></li>
+<li><a class="reference internal" href="#section-12" id="toc-entry-15">12.0.2.0.0 (2019-05-28)</a></li>
+<li><a class="reference internal" href="#section-13" id="toc-entry-16">12.0.1.0.0 (2019-02-18)</a></li>
+<li><a class="reference internal" href="#section-14" id="toc-entry-17">11.0.1.0.0 (2018-05-09)</a></li>
+<li><a class="reference internal" href="#section-15" id="toc-entry-18">10.0.1.0.0 (2018-03-26)</a></li>
+<li><a class="reference internal" href="#section-16" id="toc-entry-19">9.0.1.0.0 (2017-12-02)</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-19">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-20">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-21">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-22">Contributors</a></li>
-<li><a class="reference internal" href="#other-credits" id="toc-entry-23">Other credits</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-24">Maintainers</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-20">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-21">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-22">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-23">Contributors</a></li>
+<li><a class="reference internal" href="#other-credits" id="toc-entry-24">Other credits</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-25">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -489,17 +490,33 @@ recurring updates that can change the expected behavior.</p>
 <div class="section" id="changelog">
 <h2><a class="toc-backref" href="#toc-entry-3">Changelog</a></h2>
 <div class="section" id="section-1">
-<h3><a class="toc-backref" href="#toc-entry-4">17.0.1.0.0 (2024-01-10)</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-4">19.0.1.0.1 (2026-05-12)</a></h3>
+<p>Fixes:</p>
+<ul class="simple">
+<li>Restore auto-promotion of the lowest-sequence review to <tt class="docutils literal">pending</tt>
+immediately after <tt class="docutils literal">request_validation</tt> so the workflow can move
+forward without an external trigger. The 19.0 migration had moved this
+side-effect out of <tt class="docutils literal">_compute_can_review</tt> into a separate
+<tt class="docutils literal">_update_review_status</tt> that was only invoked when the requester was
+themself the first reviewer or when <tt class="docutils literal">notify_on_create</tt> was set,
+leaving reviews stuck in <tt class="docutils literal">waiting</tt> in every other case.</li>
+<li>Coerce <tt class="docutils literal">next_review</tt> to <tt class="docutils literal">False</tt> when no review is pending, so the
+“needs to be validated” banner no longer leaks the empty
+<tt class="docutils literal">tier.review()</tt> recordset repr into its <tt class="docutils literal">Char</tt> field.</li>
+</ul>
+</div>
+<div class="section" id="section-2">
+<h3><a class="toc-backref" href="#toc-entry-5">17.0.1.0.0 (2024-01-10)</a></h3>
 <p>Migrated to Odoo 17. Merged module with tier_validation_waiting. To
 support sending messages in a validation sequence when it is their turn
 to validate.</p>
 </div>
-<div class="section" id="section-2">
-<h3><a class="toc-backref" href="#toc-entry-5">14.0.1.0.0 (2020-11-19)</a></h3>
+<div class="section" id="section-3">
+<h3><a class="toc-backref" href="#toc-entry-6">14.0.1.0.0 (2020-11-19)</a></h3>
 <p>Migrated to Odoo 14.</p>
 </div>
-<div class="section" id="section-3">
-<h3><a class="toc-backref" href="#toc-entry-6">13.0.1.2.2 (2020-08-30)</a></h3>
+<div class="section" id="section-4">
+<h3><a class="toc-backref" href="#toc-entry-7">13.0.1.2.2 (2020-08-30)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>When using approve_sequence option in any tier.definition there can be
@@ -508,84 +525,84 @@ inconsistencies in the systray notifications</li>
 sequence, but also other sequence for the same approver</li>
 </ul>
 </div>
-<div class="section" id="section-4">
-<h3><a class="toc-backref" href="#toc-entry-7">12.0.3.3.1 (2019-12-02)</a></h3>
+<div class="section" id="section-5">
+<h3><a class="toc-backref" href="#toc-entry-8">12.0.3.3.1 (2019-12-02)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Show comment on Reviews Table.</li>
 <li>Edit notification with approve_sequence.</li>
 </ul>
 </div>
-<div class="section" id="section-5">
-<h3><a class="toc-backref" href="#toc-entry-8">12.0.3.3.0 (2019-11-27)</a></h3>
+<div class="section" id="section-6">
+<h3><a class="toc-backref" href="#toc-entry-9">12.0.3.3.0 (2019-11-27)</a></h3>
 <p>New features:</p>
 <ul class="simple">
 <li>Add comment on Reviews Table.</li>
 <li>Approve by sequence.</li>
 </ul>
 </div>
-<div class="section" id="section-6">
-<h3><a class="toc-backref" href="#toc-entry-9">12.0.3.2.1 (2019-11-26)</a></h3>
+<div class="section" id="section-7">
+<h3><a class="toc-backref" href="#toc-entry-10">12.0.3.2.1 (2019-11-26)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Remove message_subscribe_users</li>
 </ul>
 </div>
-<div class="section" id="section-7">
-<h3><a class="toc-backref" href="#toc-entry-10">12.0.3.2.0 (2019-11-25)</a></h3>
+<div class="section" id="section-8">
+<h3><a class="toc-backref" href="#toc-entry-11">12.0.3.2.0 (2019-11-25)</a></h3>
 <p>New features:</p>
 <ul class="simple">
 <li>Notify reviewers</li>
 </ul>
 </div>
-<div class="section" id="section-8">
-<h3><a class="toc-backref" href="#toc-entry-11">12.0.3.1.0 (2019-07-08)</a></h3>
+<div class="section" id="section-9">
+<h3><a class="toc-backref" href="#toc-entry-12">12.0.3.1.0 (2019-07-08)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Singleton error</li>
 </ul>
 </div>
-<div class="section" id="section-9">
-<h3><a class="toc-backref" href="#toc-entry-12">12.0.3.0.0 (2019-12-02)</a></h3>
+<div class="section" id="section-10">
+<h3><a class="toc-backref" href="#toc-entry-13">12.0.3.0.0 (2019-12-02)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Edit Reviews Table</li>
 </ul>
 </div>
-<div class="section" id="section-10">
-<h3><a class="toc-backref" href="#toc-entry-13">12.0.2.1.0 (2019-05-29)</a></h3>
+<div class="section" id="section-11">
+<h3><a class="toc-backref" href="#toc-entry-14">12.0.2.1.0 (2019-05-29)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Edit drop-down style width and position</li>
 </ul>
 </div>
-<div class="section" id="section-11">
-<h3><a class="toc-backref" href="#toc-entry-14">12.0.2.0.0 (2019-05-28)</a></h3>
+<div class="section" id="section-12">
+<h3><a class="toc-backref" href="#toc-entry-15">12.0.2.0.0 (2019-05-28)</a></h3>
 <p>New features:</p>
 <ul class="simple">
 <li>Pass parameters as functions.</li>
 <li>Add Systray.</li>
 </ul>
 </div>
-<div class="section" id="section-12">
-<h3><a class="toc-backref" href="#toc-entry-15">12.0.1.0.0 (2019-02-18)</a></h3>
+<div class="section" id="section-13">
+<h3><a class="toc-backref" href="#toc-entry-16">12.0.1.0.0 (2019-02-18)</a></h3>
 <p>Migrated to Odoo 12.</p>
 </div>
-<div class="section" id="section-13">
-<h3><a class="toc-backref" href="#toc-entry-16">11.0.1.0.0 (2018-05-09)</a></h3>
+<div class="section" id="section-14">
+<h3><a class="toc-backref" href="#toc-entry-17">11.0.1.0.0 (2018-05-09)</a></h3>
 <p>Migrated to Odoo 11.</p>
 </div>
-<div class="section" id="section-14">
-<h3><a class="toc-backref" href="#toc-entry-17">10.0.1.0.0 (2018-03-26)</a></h3>
+<div class="section" id="section-15">
+<h3><a class="toc-backref" href="#toc-entry-18">10.0.1.0.0 (2018-03-26)</a></h3>
 <p>Migrated to Odoo 10.</p>
 </div>
-<div class="section" id="section-15">
-<h3><a class="toc-backref" href="#toc-entry-18">9.0.1.0.0 (2017-12-02)</a></h3>
+<div class="section" id="section-16">
+<h3><a class="toc-backref" href="#toc-entry-19">9.0.1.0.0 (2017-12-02)</a></h3>
 <p>First version.</p>
 </div>
 </div>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#toc-entry-19">Bug Tracker</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-20">Bug Tracker</a></h2>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/tier-validation/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -593,15 +610,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#toc-entry-20">Credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-21">Credits</a></h2>
 <div class="section" id="authors">
-<h3><a class="toc-backref" href="#toc-entry-21">Authors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-22">Authors</a></h3>
 <ul class="simple">
 <li>ForgeFlow</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h3><a class="toc-backref" href="#toc-entry-22">Contributors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-23">Contributors</a></h3>
 <ul class="simple">
 <li>Lois Rilo &lt;<a class="reference external" href="mailto:lois.rilo&#64;forgeflow.com">lois.rilo&#64;forgeflow.com</a>&gt;</li>
 <li>Naglis Jonaitis &lt;<a class="reference external" href="mailto:naglis&#64;versada.eu">naglis&#64;versada.eu</a>&gt;</li>
@@ -626,10 +643,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="other-credits">
-<h3><a class="toc-backref" href="#toc-entry-23">Other credits</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-24">Other credits</a></h3>
 </div>
 <div class="section" id="maintainers">
-<h3><a class="toc-backref" href="#toc-entry-24">Maintainers</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-25">Maintainers</a></h3>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/base_tier_validation/static/description/index.html
+++ b/base_tier_validation/static/description/index.html
@@ -503,6 +503,13 @@ leaving reviews stuck in <tt class="docutils literal">waiting</tt> in every othe
 <li>Coerce <tt class="docutils literal">next_review</tt> to <tt class="docutils literal">False</tt> when no review is pending, so the
 “needs to be validated” banner no longer leaks the empty
 <tt class="docutils literal">tier.review()</tt> recordset repr into its <tt class="docutils literal">Char</tt> field.</li>
+<li>Fix <tt class="docutils literal">_notify_review_available</tt> so the reviewer reached by
+<tt class="docutils literal">notify_on_pending</tt> is actually delivered the message. The
+tier-validation subtypes have <tt class="docutils literal">default=False</tt> so a plain
+<tt class="docutils literal"><span class="pre">message_subscribe(partner_ids=...)</span></tt> left the reviewer subscribed
+only to default subtypes; <tt class="docutils literal">message_post</tt> with the
+<tt class="docutils literal">mt_tier_validation_requested</tt> subtype then routed to nobody. Pass
+<tt class="docutils literal">subtype_ids</tt> explicitly (mirroring <tt class="docutils literal">_notify_review_requested</tt>).</li>
 </ul>
 </div>
 <div class="section" id="section-2">

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -579,6 +579,86 @@ class TierTierValidation(CommonTierValidation):
         self.assertTrue(review_2.done_by.id is False)
         self.assertTrue(review_2.reviewed_date is False)
 
+    def test_19a_notify_on_pending_sequence_negative(self):
+        """When ``approve_sequence`` is used, only the first reviewer in the
+        chain must receive a ``notify_on_pending`` notification. The next
+        reviewer must NOT be subscribed and must NOT receive a message until
+        their predecessor has approved.
+        """
+        # Fresh definitions so the test is self-contained: both have
+        # ``notify_on_pending=True`` so the difference between sequence
+        # positions is what is being asserted.
+        TierDefinition = self.env["tier.definition"]
+        test_record = self.test_model.create({"test_field": 5.0})
+        def_first = TierDefinition.create(
+            {
+                "model_id": self.tester_model.id,
+                "review_type": "individual",
+                "reviewer_id": self.test_user_1.id,
+                "definition_domain": "[('test_field', '>', 4.0)]",
+                "approve_sequence": True,
+                "notify_on_pending": True,
+                "sequence": 20,
+                "name": "First in sequence -- user 1",
+            }
+        )
+        def_second = TierDefinition.create(
+            {
+                "model_id": self.tester_model.id,
+                "review_type": "individual",
+                "reviewer_id": self.test_user_2.id,
+                "definition_domain": "[('test_field', '>', 4.0)]",
+                "approve_sequence": True,
+                "notify_on_pending": True,
+                "sequence": 10,
+                "name": "Second in sequence -- user 2",
+            }
+        )
+
+        reviews = test_record.request_validation()
+        # ``request_validation`` iterates definitions in ``sequence desc``, so
+        # def_first (sequence=20) becomes tier.review.sequence=1 and def_second
+        # (sequence=10) becomes tier.review.sequence=2.
+        review_first = reviews.filtered(lambda r: r.definition_id == def_first)
+        review_second = reviews.filtered(lambda r: r.definition_id == def_second)
+        self.assertEqual(review_first.status, "pending")
+        self.assertEqual(review_second.status, "waiting")
+
+        # Exactly one chatter message must have been posted -- for the first
+        # reviewer reaching ``pending``. The second reviewer must not have been
+        # subscribed yet and must not have been notified.
+        self.assertEqual(len(test_record.message_ids), 1)
+        first_message = test_record.message_ids
+        followers = test_record.message_follower_ids
+        self.assertIn(self.test_user_1.partner_id, followers.mapped("partner_id"))
+        self.assertNotIn(
+            self.test_user_2.partner_id,
+            followers.mapped("partner_id"),
+            "Second-tier reviewer must not be subscribed to the record before "
+            "their turn.",
+        )
+        self.assertNotIn(
+            self.test_user_2.partner_id,
+            first_message.notified_partner_ids,
+            "Second-tier reviewer must not be notified before their "
+            "predecessor has approved.",
+        )
+
+        # Once the first reviewer approves, the second review must reach
+        # ``pending`` AND its reviewer must receive their own notification.
+        test_record.with_user(self.test_user_1).validate_tier()
+        self.assertEqual(review_first.status, "approved")
+        self.assertEqual(review_second.status, "pending")
+        followers = test_record.message_follower_ids
+        self.assertIn(self.test_user_2.partner_id, followers.mapped("partner_id"))
+        new_messages = test_record.message_ids - first_message
+        self.assertTrue(new_messages)
+        self.assertIn(
+            self.test_user_2.partner_id,
+            new_messages.mapped("notified_partner_ids"),
+            "Second-tier reviewer must be notified once promoted to pending.",
+        )
+
     def test_20_no_sequence(self):
         # Create new test record
         tier_review_obj = self.env["tier.review"]

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -587,15 +587,17 @@ class TierTierValidation(CommonTierValidation):
         """
         # Fresh definitions so the test is self-contained: both have
         # ``notify_on_pending=True`` so the difference between sequence
-        # positions is what is being asserted.
+        # positions is what is being asserted. Use a ``test_field`` value
+        # that does NOT match any definition created by ``common.py`` so
+        # only these two definitions apply.
         TierDefinition = self.env["tier.definition"]
-        test_record = self.test_model.create({"test_field": 5.0})
+        test_record = self.test_model.create({"test_field": 2.5})
         def_first = TierDefinition.create(
             {
                 "model_id": self.tester_model.id,
                 "review_type": "individual",
                 "reviewer_id": self.test_user_1.id,
-                "definition_domain": "[('test_field', '>', 4.0)]",
+                "definition_domain": "[('test_field', '=', 2.5)]",
                 "approve_sequence": True,
                 "notify_on_pending": True,
                 "sequence": 20,
@@ -607,7 +609,7 @@ class TierTierValidation(CommonTierValidation):
                 "model_id": self.tester_model.id,
                 "review_type": "individual",
                 "reviewer_id": self.test_user_2.id,
-                "definition_domain": "[('test_field', '>', 4.0)]",
+                "definition_domain": "[('test_field', '=', 2.5)]",
                 "approve_sequence": True,
                 "notify_on_pending": True,
                 "sequence": 10,

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -661,6 +661,35 @@ class TierTierValidation(CommonTierValidation):
             "Second-tier reviewer must be notified once promoted to pending.",
         )
 
+    def test_19b_notify_review_available_no_op_when_no_users(self):
+        """``_notify_review_available`` must short-circuit (no follower
+        added, no chatter message posted) when none of the passed reviews
+        actually wants ``notify_on_pending``. This is the defensive contract
+        that prevents stray subtype messages routed to nobody.
+        """
+        TierDefinition = self.env["tier.definition"]
+        test_record = self.test_model.create({"test_field": 2.5})
+        silent_def = TierDefinition.create(
+            {
+                "model_id": self.tester_model.id,
+                "review_type": "individual",
+                "reviewer_id": self.test_user_1.id,
+                "definition_domain": "[('test_field', '=', 2.5)]",
+                "notify_on_pending": False,
+                "sequence": 10,
+                "name": "Silent definition -- no notify_on_pending",
+            }
+        )
+        reviews = test_record.request_validation()
+        silent_review = reviews.filtered(lambda r: r.definition_id == silent_def)
+        self.assertTrue(silent_review)
+
+        followers_before = test_record.message_follower_ids
+        messages_before = test_record.message_ids
+        test_record._notify_review_available(silent_review)
+        self.assertEqual(test_record.message_follower_ids, followers_before)
+        self.assertEqual(test_record.message_ids, messages_before)
+
     def test_20_no_sequence(self):
         # Create new test record
         tier_review_obj = self.env["tier.review"]

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -139,11 +139,9 @@ class TierTierValidation(CommonTierValidation):
                 "has_comment": True,
             }
         )
-        # Request validation
+        # Request validation -- auto-promotes the single review to pending.
         review = test_record.with_user(self.test_user_2.id).request_validation()
         self.assertTrue(review)
-        # Let the normal workflow assign status 'pending' instead of waiting
-        review._update_review_status()
         record = test_record.with_user(self.test_user_1.id)
         res = record.validate_tier()
         ctx = res.get("context")
@@ -550,19 +548,19 @@ class TierTierValidation(CommonTierValidation):
         # Create new test record
         tier_review_obj = self.env["tier.review"]
         test_record = self.test_model.create({"test_field": 3.5})
-        # Request validation
+        # Request validation -- the first review must be promoted to ``pending``
+        # automatically; the second one stays ``waiting`` until its turn.
         review = test_record.request_validation()
 
         self.assertTrue(review)
-        # both reviews should be waiting when created
         review_1 = tier_review_obj.browse(review.ids[0])
         review_2 = tier_review_obj.browse(review.ids[1])
-        self.assertTrue(review_1.status == "waiting")
-        self.assertTrue(review_2.status == "waiting")
-        # and then normal workflow will follow...
         review_1.invalidate_model()
-        review_1._update_review_status()
         self.assertTrue(review_1.status == "pending")
+        # ``next_review`` must contain the pending review's definition name,
+        # not the str-representation of an empty recordset (e.g. ``tier.review()``).
+        test_record.invalidate_recordset(["next_review"])
+        self.assertEqual(test_record.next_review, f"Next: {review_1.name}")
         # first reviewer does not want notifications
         # chatter should be empty
         self.assertFalse(test_record.message_ids)
@@ -585,13 +583,13 @@ class TierTierValidation(CommonTierValidation):
         # Create new test record
         tier_review_obj = self.env["tier.review"]
         test_record2 = self.test_model.create({"test_field": 0.9})
-        # request validation
+        # Request validation -- with no approve_sequence the single review must
+        # be promoted to ``pending`` automatically and ``notify_on_pending``
+        # must trigger a chatter message.
         review = test_record2.request_validation()
         self.assertTrue(review)
         review_1 = tier_review_obj.browse(review.ids[0])
-        self.assertTrue(review_1.status == "waiting")
         review_1.invalidate_model()
-        review_1._update_review_status()
         self.assertTrue(review_1.status == "pending")
         msg2 = test_record2.message_ids[0].body
         request = test_record2._notify_requested_review_body()
@@ -1022,10 +1020,11 @@ class TierTierValidation(CommonTierValidation):
                 # Flush manually to trigger the _write
                 self.test_record_computed.flush_recordset()
         self.assertEqual(self.test_record_computed.state, "draft")
-        # The validation is performed
+        # The validation is performed -- the single review is auto-promoted
+        # to ``pending`` so the reviewer can act on it.
         self.test_record_computed.request_validation()
         self.test_record_computed.invalidate_recordset()
-        self.assertEqual(self.test_record_computed.review_ids.status, "waiting")
+        self.assertEqual(self.test_record_computed.review_ids.status, "pending")
         self.test_record_computed.with_user(self.test_user_1).validate_tier()
         self.test_record_computed.invalidate_recordset()
         self.assertEqual(self.test_record_computed.review_ids.status, "approved")


### PR DESCRIPTION
## Problem

After ``request_validation()`` reviews can stay in ``waiting`` forever when neither of these is true:

- the user requesting the validation is themself the first reviewer (so the record carries ``can_review=True``), or
- at least one tier definition has ``notify_on_create=True``.

Concrete repro:

1. Create two tier definitions on a journal entry, both with `approve_sequence=True`, sequence 10 and 20, different reviewers, and `notify_on_pending=True` (only).
2. Submit a journal entry that matches the definition domains, requested by a user who is *not* a reviewer of either tier.

Observed:

- Both reviews stay in `waiting`.
- No reviewer is notified.
- The yellow banner shows ``This Record needs to be validated. tier.review()`` -- because ``_compute_next_review`` leaks the empty recordset to its ``Char`` field when no review is pending.

Expected (and the behaviour originally introduced when merging ``base_tier_validation_waiting`` -- see [994b3f7](https://github.com/OCA/tier-validation/commit/994b3f718e828b320e1dc8a6afb540544a25c3e0)):

- The lowest-sequence review is auto-promoted to ``pending``.
- ``notify_on_pending`` reviewers are notified.
- The banner shows ``Next: <definition name>``.

The 19.0 migration ([66f964a](https://github.com/OCA/tier-validation/commit/66f964a73cea09381d61f282ddbe50440d4b5453)) refactored the auto-promote side-effect out of ``_compute_can_review`` into a separate ``_update_review_status`` method, but only wired it back into the two narrow paths above. The tests for this flow (``test_19_waiting_tier`` and ``test_20_no_sequence``) were updated to call ``_update_review_status`` manually instead of catching the regression.

## Fix

- Call ``created_trs._update_review_status()`` unconditionally inside ``request_validation`` so the available review(s) are promoted to ``pending`` right away. ``_update_review_status`` is idempotent (skips non-``waiting``), so the existing ``_update_counter`` path stays correct.
- Coerce ``next_review`` to ``False`` when no review is pending (so the ``Char`` field doesn't end up holding the repr of an empty recordset).
- Remove the now-unnecessary manual ``_update_review_status()`` calls from ``test_11_add_comment``, ``test_19_waiting_tier``, ``test_20_no_sequence`` and update ``test_28_computed_state_field`` to assert the auto-promoted state. Add an explicit regression assertion for the ``next_review`` value in ``test_19``.

## Test plan

- [x] `pytest base_tier_validation/tests` (full module suite) green
- [ ] Manual repro from the issue: 2 tier definitions by sequence, ``notify_on_pending=True``, validation requested by a non-reviewer -- first reviewer reaches ``pending`` and receives the notification; banner reads ``Next: <definition name>``.

CC @LoisRForgeFlow