### PR TITLE
[19.0][IMP] base_tier_validation: clearer notify_on_pending chatter body

### DIFF
--- a/base_tier_validation/README.rst
+++ b/base_tier_validation/README.rst
@@ -125,6 +125,21 @@ improvement will be very valuable.
 Changelog
 =========
 
+19.0.1.0.3 (2026-05-13)
+-----------------------
+
+Improvements:
+
+- ``notify_on_pending`` chatter body now names the assignee(s) so the
+  recipient can tell at a glance that the message is for them. Reuses
+  ``tier.review.todo_by`` so every review type (individual user, group,
+  ``res.users`` / ``res.groups`` field) is handled uniformly.
+- ``notify_on_pending`` chatter body now attributes the request to
+  ``review.requested_by`` (the user who actually pressed *Request
+  Validation*) instead of ``env.user``. On second-and-later tier
+  promotions ``env.user`` is the previous-tier approver, which was the
+  wrong person to credit.
+
 19.0.1.0.1 (2026-05-12)
 -----------------------
 

--- a/base_tier_validation/README.rst
+++ b/base_tier_validation/README.rst
@@ -142,6 +142,21 @@ UI improvement:
   ``to_validate_message`` Html field, which was previously defined on
   the model but never rendered.
 
+19.0.1.0.3 (2026-05-13)
+-----------------------
+
+Improvements:
+
+- ``notify_on_pending`` chatter body now names the assignee(s) so the
+  recipient can tell at a glance that the message is for them. Reuses
+  ``tier.review.todo_by`` so every review type (individual user, group,
+  ``res.users`` / ``res.groups`` field) is handled uniformly.
+- ``notify_on_pending`` chatter body now attributes the request to
+  ``review.requested_by`` (the user who actually pressed *Request
+  Validation*) instead of ``env.user``. On second-and-later tier
+  promotions ``env.user`` is the previous-tier approver, which was the
+  wrong person to credit.
+
 19.0.1.0.1 (2026-05-12)
 -----------------------
 

--- a/base_tier_validation/__manifest__.py
+++ b/base_tier_validation/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Base Tier Validation",
     "summary": "Implement a validation process based on tiers.",
-    "version": "19.0.1.0.2",
+    "version": "19.0.1.0.3",
     "development_status": "Mature",
     "maintainers": ["LoisRForgeFlow"],
     "category": "Tools",

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -725,8 +725,34 @@ class TierValidation(models.AbstractModel):
             self.env.user.name,
         )
 
-    def _notify_requested_review_body(self):
-        return self.env._("A review has been requested by %s.", self.env.user.name)
+    def _notify_requested_review_body(self, tier_reviews=None):
+        """Chatter body for a tier reaching ``pending``.
+
+        Sources the requester from the review's ``requested_by`` rather
+        than ``env.user`` -- on second-and-later tier promotions
+        ``env.user`` is the previous-tier *approver*, which is the wrong
+        person to attribute the request to.
+
+        Names the assignee(s) in the body so the recipient sees at a
+        glance that the message is meant for them (chatter notifications
+        do not render the "Notified to" pill, so the body has to carry
+        that information itself). Reuses ``tier.review.todo_by`` so the
+        wording is consistent with the Reviews table and handles every
+        review type out of the box -- individual user, group, or field.
+        """
+        if tier_reviews:
+            requester = tier_reviews[:1].requested_by or self.env.user
+            assignees = ", ".join(
+                filter(None, tier_reviews.mapped("todo_by"))
+            ) or self.env._("the assigned reviewer")
+            return self.env._(
+                "Review pending for %(assignees)s, requested by %(requester)s.",
+                assignees=assignees,
+                requester=requester.display_name,
+            )
+        return self.env._(
+            "A review has been requested by %s.", self.env.user.display_name
+        )
 
     def _notify_review_requested(self, tier_reviews):
         """method to notify when tier validation is created"""
@@ -959,7 +985,7 @@ class TierValidation(models.AbstractModel):
                 )
                 rec.message_post(
                     subtype_xmlid=self._get_requested_notification_subtype(),
-                    body=rec._notify_requested_review_body(),
+                    body=rec._notify_requested_review_body(tier_reviews),
                 )
 
 

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -746,8 +746,34 @@ class TierValidation(models.AbstractModel):
             self.env.user.name,
         )
 
-    def _notify_requested_review_body(self):
-        return self.env._("A review has been requested by %s.", self.env.user.name)
+    def _notify_requested_review_body(self, tier_reviews=None):
+        """Chatter body for a tier reaching ``pending``.
+
+        Sources the requester from the review's ``requested_by`` rather
+        than ``env.user`` -- on second-and-later tier promotions
+        ``env.user`` is the previous-tier *approver*, which is the wrong
+        person to attribute the request to.
+
+        Names the assignee(s) in the body so the recipient sees at a
+        glance that the message is meant for them (chatter notifications
+        do not render the "Notified to" pill, so the body has to carry
+        that information itself). Reuses ``tier.review.todo_by`` so the
+        wording is consistent with the Reviews table and handles every
+        review type out of the box -- individual user, group, or field.
+        """
+        if tier_reviews:
+            requester = tier_reviews[:1].requested_by or self.env.user
+            assignees = ", ".join(
+                filter(None, tier_reviews.mapped("todo_by"))
+            ) or self.env._("the assigned reviewer")
+            return self.env._(
+                "Review pending for %(assignees)s, requested by %(requester)s.",
+                assignees=assignees,
+                requester=requester.display_name,
+            )
+        return self.env._(
+            "A review has been requested by %s.", self.env.user.display_name
+        )
 
     def _notify_review_requested(self, tier_reviews):
         """method to notify when tier validation is created"""
@@ -980,7 +1006,7 @@ class TierValidation(models.AbstractModel):
                 )
                 rec.message_post(
                     subtype_xmlid=self._get_requested_notification_subtype(),
-                    body=rec._notify_requested_review_body(),
+                    body=rec._notify_requested_review_body(tier_reviews),
                 )
 
 

--- a/base_tier_validation/readme/HISTORY.md
+++ b/base_tier_validation/readme/HISTORY.md
@@ -1,3 +1,17 @@
+## 19.0.1.0.3 (2026-05-13)
+
+Improvements:
+
+- ``notify_on_pending`` chatter body now names the assignee(s) so the
+  recipient can tell at a glance that the message is for them. Reuses
+  ``tier.review.todo_by`` so every review type (individual user,
+  group, ``res.users`` / ``res.groups`` field) is handled uniformly.
+- ``notify_on_pending`` chatter body now attributes the request to
+  ``review.requested_by`` (the user who actually pressed *Request
+  Validation*) instead of ``env.user``. On second-and-later tier
+  promotions ``env.user`` is the previous-tier approver, which was the
+  wrong person to credit.
+
 ## 19.0.1.0.1 (2026-05-12)
 
 Fixes:

--- a/base_tier_validation/readme/HISTORY.md
+++ b/base_tier_validation/readme/HISTORY.md
@@ -15,6 +15,20 @@ UI improvement:
   field, which was previously defined on the model but never
   rendered.
 
+## 19.0.1.0.3 (2026-05-13)
+
+Improvements:
+
+- ``notify_on_pending`` chatter body now names the assignee(s) so the
+  recipient can tell at a glance that the message is for them. Reuses
+  ``tier.review.todo_by`` so every review type (individual user,
+  group, ``res.users`` / ``res.groups`` field) is handled uniformly.
+- ``notify_on_pending`` chatter body now attributes the request to
+  ``review.requested_by`` (the user who actually pressed *Request
+  Validation*) instead of ``env.user``. On second-and-later tier
+  promotions ``env.user`` is the previous-tier approver, which was the
+  wrong person to credit.
+
 ## 19.0.1.0.1 (2026-05-12)
 
 Fixes:

--- a/base_tier_validation/static/description/index.html
+++ b/base_tier_validation/static/description/index.html
@@ -398,30 +398,31 @@ compute method in <tt class="docutils literal">_get_after_validation_exceptions<
 <li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
 <li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-2">Known issues / Roadmap</a></li>
 <li><a class="reference internal" href="#changelog" id="toc-entry-3">Changelog</a><ul>
-<li><a class="reference internal" href="#section-1" id="toc-entry-4">19.0.1.0.1 (2026-05-12)</a></li>
-<li><a class="reference internal" href="#section-2" id="toc-entry-5">17.0.1.0.0 (2024-01-10)</a></li>
-<li><a class="reference internal" href="#section-3" id="toc-entry-6">14.0.1.0.0 (2020-11-19)</a></li>
-<li><a class="reference internal" href="#section-4" id="toc-entry-7">13.0.1.2.2 (2020-08-30)</a></li>
-<li><a class="reference internal" href="#section-5" id="toc-entry-8">12.0.3.3.1 (2019-12-02)</a></li>
-<li><a class="reference internal" href="#section-6" id="toc-entry-9">12.0.3.3.0 (2019-11-27)</a></li>
-<li><a class="reference internal" href="#section-7" id="toc-entry-10">12.0.3.2.1 (2019-11-26)</a></li>
-<li><a class="reference internal" href="#section-8" id="toc-entry-11">12.0.3.2.0 (2019-11-25)</a></li>
-<li><a class="reference internal" href="#section-9" id="toc-entry-12">12.0.3.1.0 (2019-07-08)</a></li>
-<li><a class="reference internal" href="#section-10" id="toc-entry-13">12.0.3.0.0 (2019-12-02)</a></li>
-<li><a class="reference internal" href="#section-11" id="toc-entry-14">12.0.2.1.0 (2019-05-29)</a></li>
-<li><a class="reference internal" href="#section-12" id="toc-entry-15">12.0.2.0.0 (2019-05-28)</a></li>
-<li><a class="reference internal" href="#section-13" id="toc-entry-16">12.0.1.0.0 (2019-02-18)</a></li>
-<li><a class="reference internal" href="#section-14" id="toc-entry-17">11.0.1.0.0 (2018-05-09)</a></li>
-<li><a class="reference internal" href="#section-15" id="toc-entry-18">10.0.1.0.0 (2018-03-26)</a></li>
-<li><a class="reference internal" href="#section-16" id="toc-entry-19">9.0.1.0.0 (2017-12-02)</a></li>
+<li><a class="reference internal" href="#section-1" id="toc-entry-4">19.0.1.0.3 (2026-05-13)</a></li>
+<li><a class="reference internal" href="#section-2" id="toc-entry-5">19.0.1.0.1 (2026-05-12)</a></li>
+<li><a class="reference internal" href="#section-3" id="toc-entry-6">17.0.1.0.0 (2024-01-10)</a></li>
+<li><a class="reference internal" href="#section-4" id="toc-entry-7">14.0.1.0.0 (2020-11-19)</a></li>
+<li><a class="reference internal" href="#section-5" id="toc-entry-8">13.0.1.2.2 (2020-08-30)</a></li>
+<li><a class="reference internal" href="#section-6" id="toc-entry-9">12.0.3.3.1 (2019-12-02)</a></li>
+<li><a class="reference internal" href="#section-7" id="toc-entry-10">12.0.3.3.0 (2019-11-27)</a></li>
+<li><a class="reference internal" href="#section-8" id="toc-entry-11">12.0.3.2.1 (2019-11-26)</a></li>
+<li><a class="reference internal" href="#section-9" id="toc-entry-12">12.0.3.2.0 (2019-11-25)</a></li>
+<li><a class="reference internal" href="#section-10" id="toc-entry-13">12.0.3.1.0 (2019-07-08)</a></li>
+<li><a class="reference internal" href="#section-11" id="toc-entry-14">12.0.3.0.0 (2019-12-02)</a></li>
+<li><a class="reference internal" href="#section-12" id="toc-entry-15">12.0.2.1.0 (2019-05-29)</a></li>
+<li><a class="reference internal" href="#section-13" id="toc-entry-16">12.0.2.0.0 (2019-05-28)</a></li>
+<li><a class="reference internal" href="#section-14" id="toc-entry-17">12.0.1.0.0 (2019-02-18)</a></li>
+<li><a class="reference internal" href="#section-15" id="toc-entry-18">11.0.1.0.0 (2018-05-09)</a></li>
+<li><a class="reference internal" href="#section-16" id="toc-entry-19">10.0.1.0.0 (2018-03-26)</a></li>
+<li><a class="reference internal" href="#section-17" id="toc-entry-20">9.0.1.0.0 (2017-12-02)</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-20">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-21">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-22">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-23">Contributors</a></li>
-<li><a class="reference internal" href="#other-credits" id="toc-entry-24">Other credits</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-25">Maintainers</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-21">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-22">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-23">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-24">Contributors</a></li>
+<li><a class="reference internal" href="#other-credits" id="toc-entry-25">Other credits</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-26">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -490,7 +491,22 @@ recurring updates that can change the expected behavior.</p>
 <div class="section" id="changelog">
 <h2><a class="toc-backref" href="#toc-entry-3">Changelog</a></h2>
 <div class="section" id="section-1">
-<h3><a class="toc-backref" href="#toc-entry-4">19.0.1.0.1 (2026-05-12)</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-4">19.0.1.0.3 (2026-05-13)</a></h3>
+<p>Improvements:</p>
+<ul class="simple">
+<li><tt class="docutils literal">notify_on_pending</tt> chatter body now names the assignee(s) so the
+recipient can tell at a glance that the message is for them. Reuses
+<tt class="docutils literal">tier.review.todo_by</tt> so every review type (individual user, group,
+<tt class="docutils literal">res.users</tt> / <tt class="docutils literal">res.groups</tt> field) is handled uniformly.</li>
+<li><tt class="docutils literal">notify_on_pending</tt> chatter body now attributes the request to
+<tt class="docutils literal">review.requested_by</tt> (the user who actually pressed <em>Request
+Validation</em>) instead of <tt class="docutils literal">env.user</tt>. On second-and-later tier
+promotions <tt class="docutils literal">env.user</tt> is the previous-tier approver, which was the
+wrong person to credit.</li>
+</ul>
+</div>
+<div class="section" id="section-2">
+<h3><a class="toc-backref" href="#toc-entry-5">19.0.1.0.1 (2026-05-12)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Restore auto-promotion of the lowest-sequence review to <tt class="docutils literal">pending</tt>
@@ -512,18 +528,18 @@ only to default subtypes; <tt class="docutils literal">message_post</tt> with th
 <tt class="docutils literal">subtype_ids</tt> explicitly (mirroring <tt class="docutils literal">_notify_review_requested</tt>).</li>
 </ul>
 </div>
-<div class="section" id="section-2">
-<h3><a class="toc-backref" href="#toc-entry-5">17.0.1.0.0 (2024-01-10)</a></h3>
+<div class="section" id="section-3">
+<h3><a class="toc-backref" href="#toc-entry-6">17.0.1.0.0 (2024-01-10)</a></h3>
 <p>Migrated to Odoo 17. Merged module with tier_validation_waiting. To
 support sending messages in a validation sequence when it is their turn
 to validate.</p>
 </div>
-<div class="section" id="section-3">
-<h3><a class="toc-backref" href="#toc-entry-6">14.0.1.0.0 (2020-11-19)</a></h3>
+<div class="section" id="section-4">
+<h3><a class="toc-backref" href="#toc-entry-7">14.0.1.0.0 (2020-11-19)</a></h3>
 <p>Migrated to Odoo 14.</p>
 </div>
-<div class="section" id="section-4">
-<h3><a class="toc-backref" href="#toc-entry-7">13.0.1.2.2 (2020-08-30)</a></h3>
+<div class="section" id="section-5">
+<h3><a class="toc-backref" href="#toc-entry-8">13.0.1.2.2 (2020-08-30)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>When using approve_sequence option in any tier.definition there can be
@@ -532,84 +548,84 @@ inconsistencies in the systray notifications</li>
 sequence, but also other sequence for the same approver</li>
 </ul>
 </div>
-<div class="section" id="section-5">
-<h3><a class="toc-backref" href="#toc-entry-8">12.0.3.3.1 (2019-12-02)</a></h3>
+<div class="section" id="section-6">
+<h3><a class="toc-backref" href="#toc-entry-9">12.0.3.3.1 (2019-12-02)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Show comment on Reviews Table.</li>
 <li>Edit notification with approve_sequence.</li>
 </ul>
 </div>
-<div class="section" id="section-6">
-<h3><a class="toc-backref" href="#toc-entry-9">12.0.3.3.0 (2019-11-27)</a></h3>
+<div class="section" id="section-7">
+<h3><a class="toc-backref" href="#toc-entry-10">12.0.3.3.0 (2019-11-27)</a></h3>
 <p>New features:</p>
 <ul class="simple">
 <li>Add comment on Reviews Table.</li>
 <li>Approve by sequence.</li>
 </ul>
 </div>
-<div class="section" id="section-7">
-<h3><a class="toc-backref" href="#toc-entry-10">12.0.3.2.1 (2019-11-26)</a></h3>
+<div class="section" id="section-8">
+<h3><a class="toc-backref" href="#toc-entry-11">12.0.3.2.1 (2019-11-26)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Remove message_subscribe_users</li>
 </ul>
 </div>
-<div class="section" id="section-8">
-<h3><a class="toc-backref" href="#toc-entry-11">12.0.3.2.0 (2019-11-25)</a></h3>
+<div class="section" id="section-9">
+<h3><a class="toc-backref" href="#toc-entry-12">12.0.3.2.0 (2019-11-25)</a></h3>
 <p>New features:</p>
 <ul class="simple">
 <li>Notify reviewers</li>
 </ul>
 </div>
-<div class="section" id="section-9">
-<h3><a class="toc-backref" href="#toc-entry-12">12.0.3.1.0 (2019-07-08)</a></h3>
+<div class="section" id="section-10">
+<h3><a class="toc-backref" href="#toc-entry-13">12.0.3.1.0 (2019-07-08)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Singleton error</li>
 </ul>
 </div>
-<div class="section" id="section-10">
-<h3><a class="toc-backref" href="#toc-entry-13">12.0.3.0.0 (2019-12-02)</a></h3>
+<div class="section" id="section-11">
+<h3><a class="toc-backref" href="#toc-entry-14">12.0.3.0.0 (2019-12-02)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Edit Reviews Table</li>
 </ul>
 </div>
-<div class="section" id="section-11">
-<h3><a class="toc-backref" href="#toc-entry-14">12.0.2.1.0 (2019-05-29)</a></h3>
+<div class="section" id="section-12">
+<h3><a class="toc-backref" href="#toc-entry-15">12.0.2.1.0 (2019-05-29)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Edit drop-down style width and position</li>
 </ul>
 </div>
-<div class="section" id="section-12">
-<h3><a class="toc-backref" href="#toc-entry-15">12.0.2.0.0 (2019-05-28)</a></h3>
+<div class="section" id="section-13">
+<h3><a class="toc-backref" href="#toc-entry-16">12.0.2.0.0 (2019-05-28)</a></h3>
 <p>New features:</p>
 <ul class="simple">
 <li>Pass parameters as functions.</li>
 <li>Add Systray.</li>
 </ul>
 </div>
-<div class="section" id="section-13">
-<h3><a class="toc-backref" href="#toc-entry-16">12.0.1.0.0 (2019-02-18)</a></h3>
+<div class="section" id="section-14">
+<h3><a class="toc-backref" href="#toc-entry-17">12.0.1.0.0 (2019-02-18)</a></h3>
 <p>Migrated to Odoo 12.</p>
 </div>
-<div class="section" id="section-14">
-<h3><a class="toc-backref" href="#toc-entry-17">11.0.1.0.0 (2018-05-09)</a></h3>
+<div class="section" id="section-15">
+<h3><a class="toc-backref" href="#toc-entry-18">11.0.1.0.0 (2018-05-09)</a></h3>
 <p>Migrated to Odoo 11.</p>
 </div>
-<div class="section" id="section-15">
-<h3><a class="toc-backref" href="#toc-entry-18">10.0.1.0.0 (2018-03-26)</a></h3>
+<div class="section" id="section-16">
+<h3><a class="toc-backref" href="#toc-entry-19">10.0.1.0.0 (2018-03-26)</a></h3>
 <p>Migrated to Odoo 10.</p>
 </div>
-<div class="section" id="section-16">
-<h3><a class="toc-backref" href="#toc-entry-19">9.0.1.0.0 (2017-12-02)</a></h3>
+<div class="section" id="section-17">
+<h3><a class="toc-backref" href="#toc-entry-20">9.0.1.0.0 (2017-12-02)</a></h3>
 <p>First version.</p>
 </div>
 </div>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#toc-entry-20">Bug Tracker</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-21">Bug Tracker</a></h2>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/tier-validation/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -617,15 +633,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#toc-entry-21">Credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-22">Credits</a></h2>
 <div class="section" id="authors">
-<h3><a class="toc-backref" href="#toc-entry-22">Authors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-23">Authors</a></h3>
 <ul class="simple">
 <li>ForgeFlow</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h3><a class="toc-backref" href="#toc-entry-23">Contributors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-24">Contributors</a></h3>
 <ul class="simple">
 <li>Lois Rilo &lt;<a class="reference external" href="mailto:lois.rilo&#64;forgeflow.com">lois.rilo&#64;forgeflow.com</a>&gt;</li>
 <li>Naglis Jonaitis &lt;<a class="reference external" href="mailto:naglis&#64;versada.eu">naglis&#64;versada.eu</a>&gt;</li>
@@ -650,10 +666,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="other-credits">
-<h3><a class="toc-backref" href="#toc-entry-24">Other credits</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-25">Other credits</a></h3>
 </div>
 <div class="section" id="maintainers">
-<h3><a class="toc-backref" href="#toc-entry-25">Maintainers</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-26">Maintainers</a></h3>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/base_tier_validation/static/description/index.html
+++ b/base_tier_validation/static/description/index.html
@@ -399,30 +399,31 @@ compute method in <tt class="docutils literal">_get_after_validation_exceptions<
 <li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-2">Known issues / Roadmap</a></li>
 <li><a class="reference internal" href="#changelog" id="toc-entry-3">Changelog</a><ul>
 <li><a class="reference internal" href="#section-1" id="toc-entry-4">19.0.1.0.4 (2026-05-13)</a></li>
-<li><a class="reference internal" href="#section-2" id="toc-entry-5">19.0.1.0.1 (2026-05-12)</a></li>
-<li><a class="reference internal" href="#section-3" id="toc-entry-6">17.0.1.0.0 (2024-01-10)</a></li>
-<li><a class="reference internal" href="#section-4" id="toc-entry-7">14.0.1.0.0 (2020-11-19)</a></li>
-<li><a class="reference internal" href="#section-5" id="toc-entry-8">13.0.1.2.2 (2020-08-30)</a></li>
-<li><a class="reference internal" href="#section-6" id="toc-entry-9">12.0.3.3.1 (2019-12-02)</a></li>
-<li><a class="reference internal" href="#section-7" id="toc-entry-10">12.0.3.3.0 (2019-11-27)</a></li>
-<li><a class="reference internal" href="#section-8" id="toc-entry-11">12.0.3.2.1 (2019-11-26)</a></li>
-<li><a class="reference internal" href="#section-9" id="toc-entry-12">12.0.3.2.0 (2019-11-25)</a></li>
-<li><a class="reference internal" href="#section-10" id="toc-entry-13">12.0.3.1.0 (2019-07-08)</a></li>
-<li><a class="reference internal" href="#section-11" id="toc-entry-14">12.0.3.0.0 (2019-12-02)</a></li>
-<li><a class="reference internal" href="#section-12" id="toc-entry-15">12.0.2.1.0 (2019-05-29)</a></li>
-<li><a class="reference internal" href="#section-13" id="toc-entry-16">12.0.2.0.0 (2019-05-28)</a></li>
-<li><a class="reference internal" href="#section-14" id="toc-entry-17">12.0.1.0.0 (2019-02-18)</a></li>
-<li><a class="reference internal" href="#section-15" id="toc-entry-18">11.0.1.0.0 (2018-05-09)</a></li>
-<li><a class="reference internal" href="#section-16" id="toc-entry-19">10.0.1.0.0 (2018-03-26)</a></li>
-<li><a class="reference internal" href="#section-17" id="toc-entry-20">9.0.1.0.0 (2017-12-02)</a></li>
+<li><a class="reference internal" href="#section-2" id="toc-entry-5">19.0.1.0.3 (2026-05-13)</a></li>
+<li><a class="reference internal" href="#section-3" id="toc-entry-6">19.0.1.0.1 (2026-05-12)</a></li>
+<li><a class="reference internal" href="#section-4" id="toc-entry-7">17.0.1.0.0 (2024-01-10)</a></li>
+<li><a class="reference internal" href="#section-5" id="toc-entry-8">14.0.1.0.0 (2020-11-19)</a></li>
+<li><a class="reference internal" href="#section-6" id="toc-entry-9">13.0.1.2.2 (2020-08-30)</a></li>
+<li><a class="reference internal" href="#section-7" id="toc-entry-10">12.0.3.3.1 (2019-12-02)</a></li>
+<li><a class="reference internal" href="#section-8" id="toc-entry-11">12.0.3.3.0 (2019-11-27)</a></li>
+<li><a class="reference internal" href="#section-9" id="toc-entry-12">12.0.3.2.1 (2019-11-26)</a></li>
+<li><a class="reference internal" href="#section-10" id="toc-entry-13">12.0.3.2.0 (2019-11-25)</a></li>
+<li><a class="reference internal" href="#section-11" id="toc-entry-14">12.0.3.1.0 (2019-07-08)</a></li>
+<li><a class="reference internal" href="#section-12" id="toc-entry-15">12.0.3.0.0 (2019-12-02)</a></li>
+<li><a class="reference internal" href="#section-13" id="toc-entry-16">12.0.2.1.0 (2019-05-29)</a></li>
+<li><a class="reference internal" href="#section-14" id="toc-entry-17">12.0.2.0.0 (2019-05-28)</a></li>
+<li><a class="reference internal" href="#section-15" id="toc-entry-18">12.0.1.0.0 (2019-02-18)</a></li>
+<li><a class="reference internal" href="#section-16" id="toc-entry-19">11.0.1.0.0 (2018-05-09)</a></li>
+<li><a class="reference internal" href="#section-17" id="toc-entry-20">10.0.1.0.0 (2018-03-26)</a></li>
+<li><a class="reference internal" href="#section-18" id="toc-entry-21">9.0.1.0.0 (2017-12-02)</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-21">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-22">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-23">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-24">Contributors</a></li>
-<li><a class="reference internal" href="#other-credits" id="toc-entry-25">Other credits</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-26">Maintainers</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-22">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-23">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-24">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-25">Contributors</a></li>
+<li><a class="reference internal" href="#other-credits" id="toc-entry-26">Other credits</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-27">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -508,7 +509,22 @@ the model but never rendered.</li>
 </ul>
 </div>
 <div class="section" id="section-2">
-<h3><a class="toc-backref" href="#toc-entry-5">19.0.1.0.1 (2026-05-12)</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-5">19.0.1.0.3 (2026-05-13)</a></h3>
+<p>Improvements:</p>
+<ul class="simple">
+<li><tt class="docutils literal">notify_on_pending</tt> chatter body now names the assignee(s) so the
+recipient can tell at a glance that the message is for them. Reuses
+<tt class="docutils literal">tier.review.todo_by</tt> so every review type (individual user, group,
+<tt class="docutils literal">res.users</tt> / <tt class="docutils literal">res.groups</tt> field) is handled uniformly.</li>
+<li><tt class="docutils literal">notify_on_pending</tt> chatter body now attributes the request to
+<tt class="docutils literal">review.requested_by</tt> (the user who actually pressed <em>Request
+Validation</em>) instead of <tt class="docutils literal">env.user</tt>. On second-and-later tier
+promotions <tt class="docutils literal">env.user</tt> is the previous-tier approver, which was the
+wrong person to credit.</li>
+</ul>
+</div>
+<div class="section" id="section-3">
+<h3><a class="toc-backref" href="#toc-entry-6">19.0.1.0.1 (2026-05-12)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Restore auto-promotion of the lowest-sequence review to <tt class="docutils literal">pending</tt>
@@ -530,18 +546,18 @@ only to default subtypes; <tt class="docutils literal">message_post</tt> with th
 <tt class="docutils literal">subtype_ids</tt> explicitly (mirroring <tt class="docutils literal">_notify_review_requested</tt>).</li>
 </ul>
 </div>
-<div class="section" id="section-3">
-<h3><a class="toc-backref" href="#toc-entry-6">17.0.1.0.0 (2024-01-10)</a></h3>
+<div class="section" id="section-4">
+<h3><a class="toc-backref" href="#toc-entry-7">17.0.1.0.0 (2024-01-10)</a></h3>
 <p>Migrated to Odoo 17. Merged module with tier_validation_waiting. To
 support sending messages in a validation sequence when it is their turn
 to validate.</p>
 </div>
-<div class="section" id="section-4">
-<h3><a class="toc-backref" href="#toc-entry-7">14.0.1.0.0 (2020-11-19)</a></h3>
+<div class="section" id="section-5">
+<h3><a class="toc-backref" href="#toc-entry-8">14.0.1.0.0 (2020-11-19)</a></h3>
 <p>Migrated to Odoo 14.</p>
 </div>
-<div class="section" id="section-5">
-<h3><a class="toc-backref" href="#toc-entry-8">13.0.1.2.2 (2020-08-30)</a></h3>
+<div class="section" id="section-6">
+<h3><a class="toc-backref" href="#toc-entry-9">13.0.1.2.2 (2020-08-30)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>When using approve_sequence option in any tier.definition there can be
@@ -550,84 +566,84 @@ inconsistencies in the systray notifications</li>
 sequence, but also other sequence for the same approver</li>
 </ul>
 </div>
-<div class="section" id="section-6">
-<h3><a class="toc-backref" href="#toc-entry-9">12.0.3.3.1 (2019-12-02)</a></h3>
+<div class="section" id="section-7">
+<h3><a class="toc-backref" href="#toc-entry-10">12.0.3.3.1 (2019-12-02)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Show comment on Reviews Table.</li>
 <li>Edit notification with approve_sequence.</li>
 </ul>
 </div>
-<div class="section" id="section-7">
-<h3><a class="toc-backref" href="#toc-entry-10">12.0.3.3.0 (2019-11-27)</a></h3>
+<div class="section" id="section-8">
+<h3><a class="toc-backref" href="#toc-entry-11">12.0.3.3.0 (2019-11-27)</a></h3>
 <p>New features:</p>
 <ul class="simple">
 <li>Add comment on Reviews Table.</li>
 <li>Approve by sequence.</li>
 </ul>
 </div>
-<div class="section" id="section-8">
-<h3><a class="toc-backref" href="#toc-entry-11">12.0.3.2.1 (2019-11-26)</a></h3>
+<div class="section" id="section-9">
+<h3><a class="toc-backref" href="#toc-entry-12">12.0.3.2.1 (2019-11-26)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Remove message_subscribe_users</li>
 </ul>
 </div>
-<div class="section" id="section-9">
-<h3><a class="toc-backref" href="#toc-entry-12">12.0.3.2.0 (2019-11-25)</a></h3>
+<div class="section" id="section-10">
+<h3><a class="toc-backref" href="#toc-entry-13">12.0.3.2.0 (2019-11-25)</a></h3>
 <p>New features:</p>
 <ul class="simple">
 <li>Notify reviewers</li>
 </ul>
 </div>
-<div class="section" id="section-10">
-<h3><a class="toc-backref" href="#toc-entry-13">12.0.3.1.0 (2019-07-08)</a></h3>
+<div class="section" id="section-11">
+<h3><a class="toc-backref" href="#toc-entry-14">12.0.3.1.0 (2019-07-08)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Singleton error</li>
 </ul>
 </div>
-<div class="section" id="section-11">
-<h3><a class="toc-backref" href="#toc-entry-14">12.0.3.0.0 (2019-12-02)</a></h3>
+<div class="section" id="section-12">
+<h3><a class="toc-backref" href="#toc-entry-15">12.0.3.0.0 (2019-12-02)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Edit Reviews Table</li>
 </ul>
 </div>
-<div class="section" id="section-12">
-<h3><a class="toc-backref" href="#toc-entry-15">12.0.2.1.0 (2019-05-29)</a></h3>
+<div class="section" id="section-13">
+<h3><a class="toc-backref" href="#toc-entry-16">12.0.2.1.0 (2019-05-29)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Edit drop-down style width and position</li>
 </ul>
 </div>
-<div class="section" id="section-13">
-<h3><a class="toc-backref" href="#toc-entry-16">12.0.2.0.0 (2019-05-28)</a></h3>
+<div class="section" id="section-14">
+<h3><a class="toc-backref" href="#toc-entry-17">12.0.2.0.0 (2019-05-28)</a></h3>
 <p>New features:</p>
 <ul class="simple">
 <li>Pass parameters as functions.</li>
 <li>Add Systray.</li>
 </ul>
 </div>
-<div class="section" id="section-14">
-<h3><a class="toc-backref" href="#toc-entry-17">12.0.1.0.0 (2019-02-18)</a></h3>
+<div class="section" id="section-15">
+<h3><a class="toc-backref" href="#toc-entry-18">12.0.1.0.0 (2019-02-18)</a></h3>
 <p>Migrated to Odoo 12.</p>
 </div>
-<div class="section" id="section-15">
-<h3><a class="toc-backref" href="#toc-entry-18">11.0.1.0.0 (2018-05-09)</a></h3>
+<div class="section" id="section-16">
+<h3><a class="toc-backref" href="#toc-entry-19">11.0.1.0.0 (2018-05-09)</a></h3>
 <p>Migrated to Odoo 11.</p>
 </div>
-<div class="section" id="section-16">
-<h3><a class="toc-backref" href="#toc-entry-19">10.0.1.0.0 (2018-03-26)</a></h3>
+<div class="section" id="section-17">
+<h3><a class="toc-backref" href="#toc-entry-20">10.0.1.0.0 (2018-03-26)</a></h3>
 <p>Migrated to Odoo 10.</p>
 </div>
-<div class="section" id="section-17">
-<h3><a class="toc-backref" href="#toc-entry-20">9.0.1.0.0 (2017-12-02)</a></h3>
+<div class="section" id="section-18">
+<h3><a class="toc-backref" href="#toc-entry-21">9.0.1.0.0 (2017-12-02)</a></h3>
 <p>First version.</p>
 </div>
 </div>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#toc-entry-21">Bug Tracker</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-22">Bug Tracker</a></h2>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/tier-validation/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -635,15 +651,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#toc-entry-22">Credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-23">Credits</a></h2>
 <div class="section" id="authors">
-<h3><a class="toc-backref" href="#toc-entry-23">Authors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-24">Authors</a></h3>
 <ul class="simple">
 <li>ForgeFlow</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h3><a class="toc-backref" href="#toc-entry-24">Contributors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-25">Contributors</a></h3>
 <ul class="simple">
 <li>Lois Rilo &lt;<a class="reference external" href="mailto:lois.rilo&#64;forgeflow.com">lois.rilo&#64;forgeflow.com</a>&gt;</li>
 <li>Naglis Jonaitis &lt;<a class="reference external" href="mailto:naglis&#64;versada.eu">naglis&#64;versada.eu</a>&gt;</li>
@@ -668,10 +684,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="other-credits">
-<h3><a class="toc-backref" href="#toc-entry-25">Other credits</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-26">Other credits</a></h3>
 </div>
 <div class="section" id="maintainers">
-<h3><a class="toc-backref" href="#toc-entry-26">Maintainers</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-27">Maintainers</a></h3>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -631,6 +631,12 @@ class TierTierValidation(CommonTierValidation):
         # subscribed yet and must not have been notified.
         self.assertEqual(len(test_record.message_ids), 1)
         first_message = test_record.message_ids
+        # The body must name the assignee (so the recipient sees at a glance
+        # that the message is for them, since chatter does not render the
+        # "Notified to" pill for system notifications) and attribute the
+        # request to the original requester.
+        self.assertIn(review_first.todo_by, first_message.body)
+        self.assertIn(self.env.user.display_name, first_message.body)
         followers = test_record.message_follower_ids
         self.assertIn(self.test_user_1.partner_id, followers.mapped("partner_id"))
         self.assertNotIn(
@@ -659,6 +665,20 @@ class TierTierValidation(CommonTierValidation):
             self.test_user_2.partner_id,
             new_messages.mapped("notified_partner_ids"),
             "Second-tier reviewer must be notified once promoted to pending.",
+        )
+        # Regression guard for the attribution bug: ``env.user`` at second-
+        # tier promotion time is the tier-1 approver (``test_user_1``), but
+        # the body must attribute the request to the original requester
+        # (the env user when ``request_validation`` was called). The body
+        # must also name the second-tier assignee.
+        second_body = new_messages[0].body
+        self.assertIn(review_second.todo_by, second_body)
+        self.assertIn(self.env.user.display_name, second_body)
+        self.assertNotIn(
+            self.test_user_1.display_name,
+            second_body,
+            "Second-tier message must not attribute the request to the "
+            "tier-1 approver -- that's the wrong person.",
         )
 
     def test_19b_notify_review_available_no_op_when_no_users(self):
@@ -703,8 +723,12 @@ class TierTierValidation(CommonTierValidation):
         review_1.invalidate_model()
         self.assertTrue(review_1.status == "pending")
         msg2 = test_record2.message_ids[0].body
-        request = test_record2._notify_requested_review_body()
+        # The promotion body now carries the assignee + the original
+        # requester (sourced from ``review.requested_by``, not env.user).
+        request = test_record2._notify_requested_review_body(review_1)
         self.assertIn(request, msg2)
+        self.assertIn(review_1.todo_by, msg2)
+        self.assertIn(review_1.requested_by.display_name, msg2)
 
     def test_21_notify_on_create(self):
         # notify on create

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -727,6 +727,12 @@ class TierTierValidation(CommonTierValidation):
         # subscribed yet and must not have been notified.
         self.assertEqual(len(test_record.message_ids), 1)
         first_message = test_record.message_ids
+        # The body must name the assignee (so the recipient sees at a glance
+        # that the message is for them, since chatter does not render the
+        # "Notified to" pill for system notifications) and attribute the
+        # request to the original requester.
+        self.assertIn(review_first.todo_by, first_message.body)
+        self.assertIn(self.env.user.display_name, first_message.body)
         followers = test_record.message_follower_ids
         self.assertIn(self.test_user_1.partner_id, followers.mapped("partner_id"))
         self.assertNotIn(
@@ -755,6 +761,20 @@ class TierTierValidation(CommonTierValidation):
             self.test_user_2.partner_id,
             new_messages.mapped("notified_partner_ids"),
             "Second-tier reviewer must be notified once promoted to pending.",
+        )
+        # Regression guard for the attribution bug: ``env.user`` at second-
+        # tier promotion time is the tier-1 approver (``test_user_1``), but
+        # the body must attribute the request to the original requester
+        # (the env user when ``request_validation`` was called). The body
+        # must also name the second-tier assignee.
+        second_body = new_messages[0].body
+        self.assertIn(review_second.todo_by, second_body)
+        self.assertIn(self.env.user.display_name, second_body)
+        self.assertNotIn(
+            self.test_user_1.display_name,
+            second_body,
+            "Second-tier message must not attribute the request to the "
+            "tier-1 approver -- that's the wrong person.",
         )
 
     def test_19b_notify_review_available_no_op_when_no_users(self):
@@ -848,8 +868,12 @@ class TierTierValidation(CommonTierValidation):
         review_1.invalidate_model()
         self.assertTrue(review_1.status == "pending")
         msg2 = test_record2.message_ids[0].body
-        request = test_record2._notify_requested_review_body()
+        # The promotion body now carries the assignee + the original
+        # requester (sourced from ``review.requested_by``, not env.user).
+        request = test_record2._notify_requested_review_body(review_1)
         self.assertIn(request, msg2)
+        self.assertIn(review_1.todo_by, msg2)
+        self.assertIn(review_1.requested_by.display_name, msg2)
 
     def test_21_notify_on_create(self):
         # notify on create


### PR DESCRIPTION
## Problem

The chatter message posted when a tier reaches ``pending`` (from ``_notify_review_available``) has two UX problems users have reported:

1. **Wrong attribution on later tiers.** The body reads *"A review has been requested by Administrator"* on tier 1 and then, after tier 1 is approved and tier 2 is auto-promoted, *"A review has been requested by Tier-1-Reviewer"*. The previous reviewer never pressed *Request Validation* -- they pressed *Validate* -- so crediting them for requesting the next tier is misleading. Cause: ``self.env.user.name`` inside ``_notify_review_available`` resolves to whichever user happened to trigger the promotion, not the original requester. On the second tier that's the tier-1 *approver*.

2. **No way to tell who the message is for.** Chatter system notifications do not render the "Notified to" pill the way user-typed comments do. A recipient seeing *"A review has been requested by Administrator"* in their inbox cannot tell whether the message was meant for them or for somebody else.

## Fix

- Pass the affected ``tier_reviews`` to ``_notify_requested_review_body``; source the requester from ``review.requested_by`` (set once at ``request_validation`` time, never reassigned) so the attribution is consistent across all tiers.
- Reuse the existing ``tier.review.todo_by`` field for the assignee label. It already handles every review type:
    - individual / Python expression / ``res.users`` field: name(s), abbreviated past 3 with *"(and N more)"*.
    - group: *"Group <Name>"*.
    - ``res.groups`` field: same logic via ``user_ids``.
- New wording: 

> # *"Review pending for Mike, requested by Administrator."*

Backwards-compatible: 
``_notify_requested_review_body()`` still works with no arguments and returns the previous short body for any downstream overrider that may call it that way (the reminder activity body, custom modules that rendered the requester body themselves, etc).

### Why not switch to ``message_type='comment'`` to get the pill

- Flips the message into the *Send Message* lane: it triggers unread counters for **every** follower (not just the assignee), counts as a human comment in chatter history, and runs *external partner* email routing rules. Internal-user followers may receive an actual email instead of just an inbox bubble.
- Audit-wise it then reads as *"Administrator wrote a message"* instead of *"tier-validation system fired a workflow event"*, which is wrong.
- Most Odoo workflows (sale approval, ``account_followup`` reminders, etc.) deliberately use ``message_type='notification'`` and put the recipient context in the body. This PR follows that convention.


## Test plan

- ``test_19a_notify_on_pending_sequence_negative`` extended to verify:
    - tier-1 message body contains the assignee (``review_first.todo_by``) and the original requester (``env.user.display_name`` from when ``request_validation`` ran),
    - tier-2 message body contains the *second* assignee (``review_second.todo_by``) and the *original* requester -- and does **not** contain the tier-1 approver's name (regression guard for the attribution bug).
- ``test_20_no_sequence`` updated to assert both the assignee and the requester are present in the body.

## Depends on

PR #21 ([FIX] base_tier_validation: auto-promote first review to pending). Branched off it so the changes compose; can be rebased onto ``19.0`` once that lands.

CC @LoisRForgeFlow