### PR TITLE
[19.0]IMP] base_tier_validation: UI clean-up

### DIFF
--- a/base_tier_validation/README.rst
+++ b/base_tier_validation/README.rst
@@ -125,6 +125,32 @@ improvement will be very valuable.
 Changelog
 =========
 
+19.0.1.1.0 (2026-05-13)
+-----------------------
+
+UI improvements:
+
+- Tier Definition search view: add an explicit *Archived* filter so
+  archived definitions can be surfaced in one click. The existing *All*
+  filter is preserved.
+- Tier Definition form view: render ``reviewer_id`` (individual review
+  type) with the ``many2one_avatar_user`` widget so the reviewer's
+  avatar is shown next to the name, matching the rest of Odoo.
+- Tier Definition list view: same ``many2one_avatar_user`` widget on
+  ``reviewer_id``.
+- Tier Definition *More Options* tab renamed to *Notifications &
+  Options* and split into two clearly-titled columns: *Notify reviewers
+  when* (all ``notify_*`` flags + ``notify_reminder_delay``) and *Review
+  options* (``has_comment``). The previous flat group mixed conceptually
+  different settings.
+- Tier Review list view: render ``requested_by`` and ``done_by`` with
+  ``many2one_avatar_user``. Add ``decoration-warning`` for pending rows
+  and ``decoration-muted`` for waiting rows so the row state is visible
+  at a glance, matching the existing decorations for rejected and
+  approved.
+- Tier Definition action: add a helpful empty-state message explaining
+  what tier definitions are and how to chain them.
+
 19.0.1.0.4 (2026-05-13)
 -----------------------
 

--- a/base_tier_validation/README.rst
+++ b/base_tier_validation/README.rst
@@ -150,6 +150,10 @@ UI improvements:
   approved.
 - Tier Definition action: add a helpful empty-state message explaining
   what tier definitions are and how to chain them.
+- Reviewer systray menu: lower its ordering so it sits with the other
+  notification menus (messaging, activities) on the right side of the
+  systray, to the right of the Enterprise AI button, instead of on the
+  far left.
 
 19.0.1.0.4 (2026-05-13)
 -----------------------

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -200,13 +200,13 @@ class TierValidation(models.AbstractModel):
         )
 
     def _get_validated_message(self):
-        msg = f"""<i class="fa fa-thumbs-up"></i> {
+        msg = f"""<i class="fa fa-check"></i> {
             self.env._("Operation has been <b>validated</b>!")
         }"""
         return self.validation_status == "validated" and msg or ""
 
     def _get_rejected_message(self):
-        msg = f"""<i class="fa fa-thumbs-down"></i> {
+        msg = f"""<i class="fa fa-times"></i> {
             self.env._("Operation has been <b>rejected</b>.")
         }"""
         return self.validation_status == "rejected" and msg or ""

--- a/base_tier_validation/readme/HISTORY.md
+++ b/base_tier_validation/readme/HISTORY.md
@@ -23,6 +23,10 @@ UI improvements:
   and approved.
 - Tier Definition action: add a helpful empty-state message
   explaining what tier definitions are and how to chain them.
+- Reviewer systray menu: lower its ordering so it sits with the other
+  notification menus (messaging, activities) on the right side of the
+  systray, to the right of the Enterprise AI button, instead of on the
+  far left.
 
 ## 19.0.1.0.4 (2026-05-13)
 

--- a/base_tier_validation/readme/HISTORY.md
+++ b/base_tier_validation/readme/HISTORY.md
@@ -1,3 +1,29 @@
+## 19.0.1.1.0 (2026-05-13)
+
+UI improvements:
+
+- Tier Definition search view: add an explicit *Archived* filter so
+  archived definitions can be surfaced in one click. The existing
+  *All* filter is preserved.
+- Tier Definition form view: render ``reviewer_id`` (individual
+  review type) with the ``many2one_avatar_user`` widget so the
+  reviewer's avatar is shown next to the name, matching the rest of
+  Odoo.
+- Tier Definition list view: same ``many2one_avatar_user`` widget on
+  ``reviewer_id``.
+- Tier Definition *More Options* tab renamed to *Notifications &
+  Options* and split into two clearly-titled columns: *Notify
+  reviewers when* (all ``notify_*`` flags + ``notify_reminder_delay``)
+  and *Review options* (``has_comment``). The previous flat group
+  mixed conceptually different settings.
+- Tier Review list view: render ``requested_by`` and ``done_by`` with
+  ``many2one_avatar_user``. Add ``decoration-warning`` for pending
+  rows and ``decoration-muted`` for waiting rows so the row state is
+  visible at a glance, matching the existing decorations for rejected
+  and approved.
+- Tier Definition action: add a helpful empty-state message
+  explaining what tier definitions are and how to chain them.
+
 ## 19.0.1.0.4 (2026-05-13)
 
 UI improvement:

--- a/base_tier_validation/static/description/index.html
+++ b/base_tier_validation/static/description/index.html
@@ -515,6 +515,10 @@ at a glance, matching the existing decorations for rejected and
 approved.</li>
 <li>Tier Definition action: add a helpful empty-state message explaining
 what tier definitions are and how to chain them.</li>
+<li>Reviewer systray menu: lower its ordering so it sits with the other
+notification menus (messaging, activities) on the right side of the
+systray, to the right of the Enterprise AI button, instead of on the
+far left.</li>
 </ul>
 </div>
 <div class="section" id="section-2">

--- a/base_tier_validation/static/description/index.html
+++ b/base_tier_validation/static/description/index.html
@@ -398,31 +398,32 @@ compute method in <tt class="docutils literal">_get_after_validation_exceptions<
 <li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
 <li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-2">Known issues / Roadmap</a></li>
 <li><a class="reference internal" href="#changelog" id="toc-entry-3">Changelog</a><ul>
-<li><a class="reference internal" href="#section-1" id="toc-entry-4">19.0.1.0.4 (2026-05-13)</a></li>
-<li><a class="reference internal" href="#section-2" id="toc-entry-5">19.0.1.0.1 (2026-05-12)</a></li>
-<li><a class="reference internal" href="#section-3" id="toc-entry-6">17.0.1.0.0 (2024-01-10)</a></li>
-<li><a class="reference internal" href="#section-4" id="toc-entry-7">14.0.1.0.0 (2020-11-19)</a></li>
-<li><a class="reference internal" href="#section-5" id="toc-entry-8">13.0.1.2.2 (2020-08-30)</a></li>
-<li><a class="reference internal" href="#section-6" id="toc-entry-9">12.0.3.3.1 (2019-12-02)</a></li>
-<li><a class="reference internal" href="#section-7" id="toc-entry-10">12.0.3.3.0 (2019-11-27)</a></li>
-<li><a class="reference internal" href="#section-8" id="toc-entry-11">12.0.3.2.1 (2019-11-26)</a></li>
-<li><a class="reference internal" href="#section-9" id="toc-entry-12">12.0.3.2.0 (2019-11-25)</a></li>
-<li><a class="reference internal" href="#section-10" id="toc-entry-13">12.0.3.1.0 (2019-07-08)</a></li>
-<li><a class="reference internal" href="#section-11" id="toc-entry-14">12.0.3.0.0 (2019-12-02)</a></li>
-<li><a class="reference internal" href="#section-12" id="toc-entry-15">12.0.2.1.0 (2019-05-29)</a></li>
-<li><a class="reference internal" href="#section-13" id="toc-entry-16">12.0.2.0.0 (2019-05-28)</a></li>
-<li><a class="reference internal" href="#section-14" id="toc-entry-17">12.0.1.0.0 (2019-02-18)</a></li>
-<li><a class="reference internal" href="#section-15" id="toc-entry-18">11.0.1.0.0 (2018-05-09)</a></li>
-<li><a class="reference internal" href="#section-16" id="toc-entry-19">10.0.1.0.0 (2018-03-26)</a></li>
-<li><a class="reference internal" href="#section-17" id="toc-entry-20">9.0.1.0.0 (2017-12-02)</a></li>
+<li><a class="reference internal" href="#section-1" id="toc-entry-4">19.0.1.1.0 (2026-05-13)</a></li>
+<li><a class="reference internal" href="#section-2" id="toc-entry-5">19.0.1.0.4 (2026-05-13)</a></li>
+<li><a class="reference internal" href="#section-3" id="toc-entry-6">19.0.1.0.1 (2026-05-12)</a></li>
+<li><a class="reference internal" href="#section-4" id="toc-entry-7">17.0.1.0.0 (2024-01-10)</a></li>
+<li><a class="reference internal" href="#section-5" id="toc-entry-8">14.0.1.0.0 (2020-11-19)</a></li>
+<li><a class="reference internal" href="#section-6" id="toc-entry-9">13.0.1.2.2 (2020-08-30)</a></li>
+<li><a class="reference internal" href="#section-7" id="toc-entry-10">12.0.3.3.1 (2019-12-02)</a></li>
+<li><a class="reference internal" href="#section-8" id="toc-entry-11">12.0.3.3.0 (2019-11-27)</a></li>
+<li><a class="reference internal" href="#section-9" id="toc-entry-12">12.0.3.2.1 (2019-11-26)</a></li>
+<li><a class="reference internal" href="#section-10" id="toc-entry-13">12.0.3.2.0 (2019-11-25)</a></li>
+<li><a class="reference internal" href="#section-11" id="toc-entry-14">12.0.3.1.0 (2019-07-08)</a></li>
+<li><a class="reference internal" href="#section-12" id="toc-entry-15">12.0.3.0.0 (2019-12-02)</a></li>
+<li><a class="reference internal" href="#section-13" id="toc-entry-16">12.0.2.1.0 (2019-05-29)</a></li>
+<li><a class="reference internal" href="#section-14" id="toc-entry-17">12.0.2.0.0 (2019-05-28)</a></li>
+<li><a class="reference internal" href="#section-15" id="toc-entry-18">12.0.1.0.0 (2019-02-18)</a></li>
+<li><a class="reference internal" href="#section-16" id="toc-entry-19">11.0.1.0.0 (2018-05-09)</a></li>
+<li><a class="reference internal" href="#section-17" id="toc-entry-20">10.0.1.0.0 (2018-03-26)</a></li>
+<li><a class="reference internal" href="#section-18" id="toc-entry-21">9.0.1.0.0 (2017-12-02)</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-21">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-22">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-23">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-24">Contributors</a></li>
-<li><a class="reference internal" href="#other-credits" id="toc-entry-25">Other credits</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-26">Maintainers</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-22">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-23">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-24">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-25">Contributors</a></li>
+<li><a class="reference internal" href="#other-credits" id="toc-entry-26">Other credits</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-27">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -491,7 +492,33 @@ recurring updates that can change the expected behavior.</p>
 <div class="section" id="changelog">
 <h2><a class="toc-backref" href="#toc-entry-3">Changelog</a></h2>
 <div class="section" id="section-1">
-<h3><a class="toc-backref" href="#toc-entry-4">19.0.1.0.4 (2026-05-13)</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-4">19.0.1.1.0 (2026-05-13)</a></h3>
+<p>UI improvements:</p>
+<ul class="simple">
+<li>Tier Definition search view: add an explicit <em>Archived</em> filter so
+archived definitions can be surfaced in one click. The existing <em>All</em>
+filter is preserved.</li>
+<li>Tier Definition form view: render <tt class="docutils literal">reviewer_id</tt> (individual review
+type) with the <tt class="docutils literal">many2one_avatar_user</tt> widget so the reviewer’s
+avatar is shown next to the name, matching the rest of Odoo.</li>
+<li>Tier Definition list view: same <tt class="docutils literal">many2one_avatar_user</tt> widget on
+<tt class="docutils literal">reviewer_id</tt>.</li>
+<li>Tier Definition <em>More Options</em> tab renamed to <em>Notifications &amp;
+Options</em> and split into two clearly-titled columns: <em>Notify reviewers
+when</em> (all <tt class="docutils literal">notify_*</tt> flags + <tt class="docutils literal">notify_reminder_delay</tt>) and <em>Review
+options</em> (<tt class="docutils literal">has_comment</tt>). The previous flat group mixed conceptually
+different settings.</li>
+<li>Tier Review list view: render <tt class="docutils literal">requested_by</tt> and <tt class="docutils literal">done_by</tt> with
+<tt class="docutils literal">many2one_avatar_user</tt>. Add <tt class="docutils literal"><span class="pre">decoration-warning</span></tt> for pending rows
+and <tt class="docutils literal"><span class="pre">decoration-muted</span></tt> for waiting rows so the row state is visible
+at a glance, matching the existing decorations for rejected and
+approved.</li>
+<li>Tier Definition action: add a helpful empty-state message explaining
+what tier definitions are and how to chain them.</li>
+</ul>
+</div>
+<div class="section" id="section-2">
+<h3><a class="toc-backref" href="#toc-entry-5">19.0.1.0.4 (2026-05-13)</a></h3>
 <p>UI improvement:</p>
 <ul class="simple">
 <li>The “needs to be validated” banner shown above tier-validated
@@ -507,8 +534,8 @@ banner template now reads from the long-standing
 the model but never rendered.</li>
 </ul>
 </div>
-<div class="section" id="section-2">
-<h3><a class="toc-backref" href="#toc-entry-5">19.0.1.0.1 (2026-05-12)</a></h3>
+<div class="section" id="section-3">
+<h3><a class="toc-backref" href="#toc-entry-6">19.0.1.0.1 (2026-05-12)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Restore auto-promotion of the lowest-sequence review to <tt class="docutils literal">pending</tt>
@@ -530,18 +557,18 @@ only to default subtypes; <tt class="docutils literal">message_post</tt> with th
 <tt class="docutils literal">subtype_ids</tt> explicitly (mirroring <tt class="docutils literal">_notify_review_requested</tt>).</li>
 </ul>
 </div>
-<div class="section" id="section-3">
-<h3><a class="toc-backref" href="#toc-entry-6">17.0.1.0.0 (2024-01-10)</a></h3>
+<div class="section" id="section-4">
+<h3><a class="toc-backref" href="#toc-entry-7">17.0.1.0.0 (2024-01-10)</a></h3>
 <p>Migrated to Odoo 17. Merged module with tier_validation_waiting. To
 support sending messages in a validation sequence when it is their turn
 to validate.</p>
 </div>
-<div class="section" id="section-4">
-<h3><a class="toc-backref" href="#toc-entry-7">14.0.1.0.0 (2020-11-19)</a></h3>
+<div class="section" id="section-5">
+<h3><a class="toc-backref" href="#toc-entry-8">14.0.1.0.0 (2020-11-19)</a></h3>
 <p>Migrated to Odoo 14.</p>
 </div>
-<div class="section" id="section-5">
-<h3><a class="toc-backref" href="#toc-entry-8">13.0.1.2.2 (2020-08-30)</a></h3>
+<div class="section" id="section-6">
+<h3><a class="toc-backref" href="#toc-entry-9">13.0.1.2.2 (2020-08-30)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>When using approve_sequence option in any tier.definition there can be
@@ -550,84 +577,84 @@ inconsistencies in the systray notifications</li>
 sequence, but also other sequence for the same approver</li>
 </ul>
 </div>
-<div class="section" id="section-6">
-<h3><a class="toc-backref" href="#toc-entry-9">12.0.3.3.1 (2019-12-02)</a></h3>
+<div class="section" id="section-7">
+<h3><a class="toc-backref" href="#toc-entry-10">12.0.3.3.1 (2019-12-02)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Show comment on Reviews Table.</li>
 <li>Edit notification with approve_sequence.</li>
 </ul>
 </div>
-<div class="section" id="section-7">
-<h3><a class="toc-backref" href="#toc-entry-10">12.0.3.3.0 (2019-11-27)</a></h3>
+<div class="section" id="section-8">
+<h3><a class="toc-backref" href="#toc-entry-11">12.0.3.3.0 (2019-11-27)</a></h3>
 <p>New features:</p>
 <ul class="simple">
 <li>Add comment on Reviews Table.</li>
 <li>Approve by sequence.</li>
 </ul>
 </div>
-<div class="section" id="section-8">
-<h3><a class="toc-backref" href="#toc-entry-11">12.0.3.2.1 (2019-11-26)</a></h3>
+<div class="section" id="section-9">
+<h3><a class="toc-backref" href="#toc-entry-12">12.0.3.2.1 (2019-11-26)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Remove message_subscribe_users</li>
 </ul>
 </div>
-<div class="section" id="section-9">
-<h3><a class="toc-backref" href="#toc-entry-12">12.0.3.2.0 (2019-11-25)</a></h3>
+<div class="section" id="section-10">
+<h3><a class="toc-backref" href="#toc-entry-13">12.0.3.2.0 (2019-11-25)</a></h3>
 <p>New features:</p>
 <ul class="simple">
 <li>Notify reviewers</li>
 </ul>
 </div>
-<div class="section" id="section-10">
-<h3><a class="toc-backref" href="#toc-entry-13">12.0.3.1.0 (2019-07-08)</a></h3>
+<div class="section" id="section-11">
+<h3><a class="toc-backref" href="#toc-entry-14">12.0.3.1.0 (2019-07-08)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Singleton error</li>
 </ul>
 </div>
-<div class="section" id="section-11">
-<h3><a class="toc-backref" href="#toc-entry-14">12.0.3.0.0 (2019-12-02)</a></h3>
+<div class="section" id="section-12">
+<h3><a class="toc-backref" href="#toc-entry-15">12.0.3.0.0 (2019-12-02)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Edit Reviews Table</li>
 </ul>
 </div>
-<div class="section" id="section-12">
-<h3><a class="toc-backref" href="#toc-entry-15">12.0.2.1.0 (2019-05-29)</a></h3>
+<div class="section" id="section-13">
+<h3><a class="toc-backref" href="#toc-entry-16">12.0.2.1.0 (2019-05-29)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Edit drop-down style width and position</li>
 </ul>
 </div>
-<div class="section" id="section-13">
-<h3><a class="toc-backref" href="#toc-entry-16">12.0.2.0.0 (2019-05-28)</a></h3>
+<div class="section" id="section-14">
+<h3><a class="toc-backref" href="#toc-entry-17">12.0.2.0.0 (2019-05-28)</a></h3>
 <p>New features:</p>
 <ul class="simple">
 <li>Pass parameters as functions.</li>
 <li>Add Systray.</li>
 </ul>
 </div>
-<div class="section" id="section-14">
-<h3><a class="toc-backref" href="#toc-entry-17">12.0.1.0.0 (2019-02-18)</a></h3>
+<div class="section" id="section-15">
+<h3><a class="toc-backref" href="#toc-entry-18">12.0.1.0.0 (2019-02-18)</a></h3>
 <p>Migrated to Odoo 12.</p>
 </div>
-<div class="section" id="section-15">
-<h3><a class="toc-backref" href="#toc-entry-18">11.0.1.0.0 (2018-05-09)</a></h3>
+<div class="section" id="section-16">
+<h3><a class="toc-backref" href="#toc-entry-19">11.0.1.0.0 (2018-05-09)</a></h3>
 <p>Migrated to Odoo 11.</p>
 </div>
-<div class="section" id="section-16">
-<h3><a class="toc-backref" href="#toc-entry-19">10.0.1.0.0 (2018-03-26)</a></h3>
+<div class="section" id="section-17">
+<h3><a class="toc-backref" href="#toc-entry-20">10.0.1.0.0 (2018-03-26)</a></h3>
 <p>Migrated to Odoo 10.</p>
 </div>
-<div class="section" id="section-17">
-<h3><a class="toc-backref" href="#toc-entry-20">9.0.1.0.0 (2017-12-02)</a></h3>
+<div class="section" id="section-18">
+<h3><a class="toc-backref" href="#toc-entry-21">9.0.1.0.0 (2017-12-02)</a></h3>
 <p>First version.</p>
 </div>
 </div>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#toc-entry-21">Bug Tracker</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-22">Bug Tracker</a></h2>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/tier-validation/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -635,15 +662,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#toc-entry-22">Credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-23">Credits</a></h2>
 <div class="section" id="authors">
-<h3><a class="toc-backref" href="#toc-entry-23">Authors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-24">Authors</a></h3>
 <ul class="simple">
 <li>ForgeFlow</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h3><a class="toc-backref" href="#toc-entry-24">Contributors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-25">Contributors</a></h3>
 <ul class="simple">
 <li>Lois Rilo &lt;<a class="reference external" href="mailto:lois.rilo&#64;forgeflow.com">lois.rilo&#64;forgeflow.com</a>&gt;</li>
 <li>Naglis Jonaitis &lt;<a class="reference external" href="mailto:naglis&#64;versada.eu">naglis&#64;versada.eu</a>&gt;</li>
@@ -668,10 +695,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="other-credits">
-<h3><a class="toc-backref" href="#toc-entry-25">Other credits</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-26">Other credits</a></h3>
 </div>
 <div class="section" id="maintainers">
-<h3><a class="toc-backref" href="#toc-entry-26">Maintainers</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-27">Maintainers</a></h3>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/base_tier_validation/static/src/components/tier_review_menu/tier_review_menu.esm.js
+++ b/base_tier_validation/static/src/components/tier_review_menu/tier_review_menu.esm.js
@@ -69,6 +69,12 @@ export const systrayItem = {
     Component: TierReviewMenu,
 };
 
+// Systray items render right-to-left by descending sequence (higher =
+// further left; the user menu at sequence 0 is the right-most). A low
+// sequence keeps the reviewer menu grouped with the standard
+// notification menus (messaging 25, activities 20) on the right, rather
+// than off on the far left -- notably to the right of the Enterprise AI
+// button (which sits left of the messaging menu, i.e. sequence > 25).
 registry
     .category("systray")
-    .add("base_tier_validation.ReviewerMenu", systrayItem, {sequence: 99});
+    .add("base_tier_validation.ReviewerMenu", systrayItem, {sequence: 24});

--- a/base_tier_validation/static/src/components/tier_review_menu/tier_review_menu.xml
+++ b/base_tier_validation/static/src/components/tier_review_menu/tier_review_menu.xml
@@ -9,11 +9,7 @@
             menuClass="discussSystray.menuClass"
         >
             <button>
-                <i
-                    class="fa fa-lg fa-pencil-square-o"
-                    role="img"
-                    aria-label="Reviews"
-                />
+                <i class="fa fa-lg fa-check-square-o" role="img" aria-label="Reviews" />
                 <span
                     t-if="store.tierReviewCounter"
                     class="o-mail-ActivityMenu-counter badge rounded-pill"

--- a/base_tier_validation/static/src/components/tier_review_widget/tier_review_widget.esm.js
+++ b/base_tier_validation/static/src/components/tier_review_widget/tier_review_widget.esm.js
@@ -17,9 +17,9 @@ export class ReviewsTable extends Component {
     }
 
     onToggleCollapse(ev) {
-        const panelHeading = ev.currentTarget.closest(".panel-heading");
-        const collapseDiv = panelHeading.nextElementSibling.matches("div#collapse1")
-            ? panelHeading.nextElementSibling
+        const cardHeader = ev.currentTarget.closest(".card-header");
+        const collapseDiv = cardHeader?.nextElementSibling?.matches("div#collapse1")
+            ? cardHeader.nextElementSibling
             : null;
         if (!collapseDiv) return;
         if (this.state.collapse) {

--- a/base_tier_validation/static/src/components/tier_review_widget/tier_review_widget.scss
+++ b/base_tier_validation/static/src/components/tier_review_widget/tier_review_widget.scss
@@ -3,39 +3,42 @@ ul.o_review {
     max-width: 800px;
 }
 
-.panel-group {
+.o_tier_review_widget {
     min-height: auto !important;
     margin-top: -6px !important;
     padding: 16px 16px 8px 16px !important;
 }
 
-.panel-heading {
-    background-color: initial !important;
-}
-
-.panel {
+.o_tier_review_widget .card {
     border: 0 !important;
 }
 
-.panel-body {
+.o_tier_review_widget .card-header {
+    background-color: initial !important;
+}
+
+.o_tier_review_widget .card-body {
     overflow-y: hidden;
     overflow-x: auto;
 }
 
-.panel-title > a,
-.panel-title > a:active {
+.o_tier_review_widget .card-title > a,
+.o_tier_review_widget .card-title > a:active {
     display: block;
 }
 
-.panel-heading a:before {
+.o_tier_review_widget .card-header a:before {
     font-family: FontAwesome;
     content: "\f0d7";
     float: right;
     transition: all 0.5s;
 }
 
-.panel-heading.active a:before {
-    -webkit-transform: rotate(180deg);
-    -moz-transform: rotate(180deg);
+.o_tier_review_widget .card-header.active a:before {
     transform: rotate(180deg);
+}
+
+.o_tier_review_widget .o_tier_review_seq {
+    width: 2rem;
+    white-space: nowrap;
 }

--- a/base_tier_validation/static/src/components/tier_review_widget/tier_review_widget.xml
+++ b/base_tier_validation/static/src/components/tier_review_widget/tier_review_widget.xml
@@ -1,46 +1,58 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates>
     <t t-name="base_tier_validation.Collapse">
-        <div class="o_form_sheet panel-group">
-            <div class="panel panel-default">
-                <div class="panel-heading">
-                    <h4 class="panel-title">
+        <div class="o_form_sheet o_tier_review_widget">
+            <div class="card">
+                <div class="card-header">
+                    <h4 class="card-title mb-0">
                         <a
                             class="o_info_btn"
-                            data-toggle="state.collapse"
+                            data-bs-toggle="state.collapse"
                             href="#"
-                            data-target="#collapse1"
+                            data-bs-target="#collapse1"
                             t-on-click="onToggleCollapse"
                         >
                             Reviews
                         </a>
                     </h4>
                 </div>
-                <div id="collapse1" class="panel-collapse collapse active">
-                    <div class="panel-body o_review">
-                        <table class="oe_mt32 table table-condensed">
+                <div id="collapse1" class="collapse show">
+                    <div class="card-body o_review">
+                        <table class="mt-4 table table-sm">
                             <thead>
                                 <tr>
                                     <th
                                         name="th_sequence"
-                                        class="text-center"
-                                    >Sequence</th>
+                                        class="text-center o_tier_review_seq"
+                                    >#</th>
                                     <th
                                         name="th_requested_by"
                                         class="text-start"
                                     >Requested by</th>
-                                    <th name="th_name" class="text-end">Description</th>
+                                    <th
+                                        name="th_name"
+                                        class="text-start"
+                                    >Description</th>
                                     <th
                                         name="th_display_status"
-                                        class="text-end"
+                                        class="text-start"
                                     >Status</th>
-                                    <th name="th_todo_by" class="text-end">Todo by</th>
-                                    <th name="th_done_by" class="text-end">Done by</th>
+                                    <th
+                                        name="th_todo_by"
+                                        class="text-start"
+                                    >Todo by</th>
+                                    <th
+                                        name="th_done_by"
+                                        class="text-start"
+                                    >Done by</th>
                                     <th
                                         name="th_reviewed_date"
-                                        class="text-end"
+                                        class="text-start"
                                     >Validation Date</th>
-                                    <th name="th_comment" class="text-end">Comment</th>
+                                    <th
+                                        name="th_comment"
+                                        class="text-start"
+                                    >Comment</th>
                                 </tr>
                             </thead>
                             <tbody class="sale_tbody">
@@ -57,20 +69,23 @@
                                     <t
                                         t-if="review.status == 'pending'"
                                         t-set="status_class"
-                                        t-value=""
+                                        t-value="''"
                                     />
                                     <t
                                         t-if="review.status == 'approved'"
                                         t-set="status_class"
-                                        t-value="'alert alert-success'"
+                                        t-value="'table-success'"
                                     />
                                     <t
                                         t-if="review.status == 'rejected'"
                                         t-set="status_class"
-                                        t-value="'alert alert-danger'"
+                                        t-value="'table-danger'"
                                     />
                                     <tr t-att-class="status_class">
-                                        <td name="td_sequence" class="text-center">
+                                        <td
+                                            name="td_sequence"
+                                            class="text-center o_tier_review_seq"
+                                        >
                                             <span t-out="review.sequence" />
                                         </td>
                                         <td name="td_requested_by" class="text-start">
@@ -78,19 +93,19 @@
                                                 t-out="review.requested_by.display_name"
                                             />
                                         </td>
-                                        <td name="td_name" class="text-end">
+                                        <td name="td_name" class="text-start">
                                             <span t-out="review.name" />
                                         </td>
-                                        <td name="td_display_status" class="text-end">
+                                        <td name="td_display_status" class="text-start">
                                             <span t-out="review.display_status" />
                                         </td>
-                                        <td name="td_todo_by" class="text-end">
+                                        <td name="td_todo_by" class="text-start">
                                             <span t-out="review.todo_by" />
                                         </td>
-                                        <td name="td_done_by" class="text-end">
+                                        <td name="td_done_by" class="text-start">
                                             <span t-out="review.done_by.display_name" />
                                         </td>
-                                        <td name="td_reviewed_date" class="text-end">
+                                        <td name="td_reviewed_date" class="text-start">
                                             <t t-if="review.reviewed_formated_date">
                                                 <span
                                                     t-out="review.reviewed_formated_date"

--- a/base_tier_validation/templates/tier_validation_templates.xml
+++ b/base_tier_validation/templates/tier_validation_templates.xml
@@ -14,6 +14,7 @@
                 string="Restart Validation"
                 invisible="not review_ids or hide_reviews"
                 type="object"
+                icon="fa-rotate-left"
             />
         </div>
     </template>
@@ -37,7 +38,7 @@
                         invisible="not can_review"
                         type="object"
                         class="btn-icon me-1 btn-success"
-                        icon="fa-thumbs-up"
+                        icon="fa-check fa-lg"
                     />
                     <button
                         name="reject_tier"
@@ -45,7 +46,7 @@
                         invisible="not can_review"
                         type="object"
                         class="btn-icon btn-danger"
-                        icon="fa-thumbs-down"
+                        icon="fa-times fa-lg"
                     />
                     <br />
                     <field name="next_review" readonly="1" />
@@ -57,7 +58,7 @@
                 t-attf-invisible="validation_status != 'validated' or hide_reviews or not review_ids"
             >
                 <p class="mb-1">
-                <i class="fa fa-lg fa-thumbs-up" />
+                <i class="fa fa-lg fa-check" />
                 Operation has been
                 <b>validated</b>
                 !
@@ -69,7 +70,7 @@
                 t-attf-invisible="validation_status != 'rejected' or hide_reviews or not review_ids"
             >
                 <p class="mb-1">
-                <i class="fa fa-lg fa-thumbs-down" />
+                <i class="fa fa-lg fa-times" />
                 Operation has been
                 <b>rejected</b>
                 .

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -120,6 +120,30 @@ class TierTierValidation(CommonTierValidation):
         record.restart_validation()
         self.assertFalse(record.review_ids)
 
+    def test_validated_and_rejected_message_icons(self):
+        """`_get_validated_message` / `_get_rejected_message` render the
+        per-status banner HTML using the check / xmark icons consistent
+        with the rest of the module's iconography. Empty until the
+        record actually reaches that state."""
+        # Until a state is reached, the banner is empty.
+        self.assertFalse(self.test_record.validated_message)
+        self.assertFalse(self.test_record.rejected_message)
+        # Validate -> banner reflects the validated state.
+        reviews = self.test_record.with_user(self.test_user_2).request_validation()
+        self.assertTrue(reviews)
+        self.test_record.with_user(self.test_user_1).validate_tier()
+        self.assertEqual(self.test_record.validation_status, "validated")
+        self.assertIn("fa-check", self.test_record.validated_message)
+        self.assertIn("validated", self.test_record.validated_message)
+        self.assertFalse(self.test_record.rejected_message)
+        # Restart + reject -> the rejected banner picks up its icon too.
+        self.test_record.restart_validation()
+        self.test_record.with_user(self.test_user_2).request_validation()
+        self.test_record.with_user(self.test_user_1).reject_tier()
+        self.assertEqual(self.test_record.validation_status, "rejected")
+        self.assertIn("fa-times", self.test_record.rejected_message)
+        self.assertIn("rejected", self.test_record.rejected_message)
+
     def test_05_under_validation(self):
         """Write is forbidden in a record under validation."""
         self.assertFalse(self.test_record.review_ids)

--- a/base_tier_validation/views/tier_definition_view.xml
+++ b/base_tier_validation/views/tier_definition_view.xml
@@ -40,7 +40,6 @@
                         invisible="active"
                     />
                     <div class="oe_title">
-                        <span class="oe_edit_only">Name</span>
                         <h1>
                             <field
                                 name="name"

--- a/base_tier_validation/views/tier_definition_view.xml
+++ b/base_tier_validation/views/tier_definition_view.xml
@@ -11,7 +11,7 @@
                 <field name="model_id" />
                 <field name="name" />
                 <field name="review_type" />
-                <field name="reviewer_id" />
+                <field name="reviewer_id" widget="many2one_avatar_user" />
                 <field name="reviewer_group_id" />
                 <field name="reviewer_field_id" />
                 <field name="notify_on_create" optional="show" />
@@ -57,6 +57,7 @@
                             <field name="allow_write_for_reviewer" />
                             <field
                                 name="reviewer_id"
+                                widget="many2one_avatar_user"
                                 invisible="review_type != 'individual'"
                             />
                             <field
@@ -109,16 +110,18 @@
                                 />
                             </group>
                         </page>
-                        <page name="options" string="More Options">
-                            <group name="more_option">
-                                <group name="notify">
+                        <page name="options" string="Notifications &amp; Options">
+                            <group>
+                                <group string="Notify reviewers when" name="notify">
                                     <field name="notify_on_create" />
                                     <field name="notify_on_pending" />
                                     <field name="notify_on_accepted" />
                                     <field name="notify_on_rejected" />
                                     <field name="notify_on_restarted" />
-                                    <field name="has_comment" />
                                     <field name="notify_reminder_delay" />
+                                </group>
+                                <group string="Review options" name="review_options">
+                                    <field name="has_comment" />
                                 </group>
                             </group>
                         </page>
@@ -138,6 +141,11 @@
                 <field name="reviewer_group_id" />
                 <field name="active" />
                 <separator />
+                <filter
+                    string="Archived"
+                    name="inactive"
+                    domain="[('active', '=', False)]"
+                />
                 <filter
                     string="All"
                     name="all"
@@ -160,6 +168,22 @@
         <field name="res_model">tier.definition</field>
         <field name="view_mode">list,form</field>
         <field name="context">{'search_default_all': 1}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Define a new validation tier
+            </p>
+            <p>
+                A tier definition tells Odoo which records on a given model need
+                to be reviewed by which user (or group, or field-based reviewer)
+                before they can move forward in their workflow.
+            </p>
+            <p>
+                Tiers can be chained -- enable
+                <em>Approve by sequence</em>
+                on each definition for the model to require the lower-sequence
+                tier to be approved first.
+            </p>
+        </field>
     </record>
     <menuitem
         id="menu_tier_confirmation"

--- a/base_tier_validation/views/tier_review_view.xml
+++ b/base_tier_validation/views/tier_review_view.xml
@@ -9,14 +9,16 @@
             <list
                 decoration-danger="status=='rejected'"
                 decoration-success="status=='approved'"
+                decoration-warning="status=='pending'"
+                decoration-muted="status=='waiting'"
             >
                 <field name="sequence" />
-                <field name="requested_by" />
+                <field name="requested_by" widget="many2one_avatar_user" />
                 <field name="review_type" />
                 <field name="name" />
                 <field name="status" />
                 <field name="todo_by" />
-                <field name="done_by" />
+                <field name="done_by" widget="many2one_avatar_user" />
                 <field name="reviewed_date" />
                 <field name="comment" />
             </list>


### PR DESCRIPTION
## What

Small UX polish on the Tier Definition / Tier Review views, picked up from feedback on a real-world rollout.

## Changes

### Tier Definition

- **Search view**: explicit *Archived* filter next to the existing *All* filter, so archived definitions can be surfaced in one click. Before, you had to type ``active = False`` into the bare search field.
- **Form view**: ``reviewer_id`` (individual review type) now uses ``widget=\"many2one_avatar_user\"`` so the reviewer's avatar is rendered next to their name. Matches the rest of Odoo (sale, project, helpdesk, etc.).
- **List view**: same avatar widget on ``reviewer_id``.
- **More Options tab**: renamed to *Notifications & Options* and split into two clearly-titled groups:
    - *Notify reviewers when*: all ``notify_*`` flags + ``notify_reminder_delay``.
    - *Review options*: ``has_comment``.

  Before, every flag sat in one flat group ``notify`` which lumped together notification routing and review-time behaviour. Two columns with explicit titles make the intent obvious.
- **Empty-state**: helpful help message on the action so a fresh install actually explains what tier definitions are and how to chain them with *Approve by sequence*.

### Tier Review (used embedded under the validated document and in the systray tray)

- Avatar widget on ``requested_by`` and ``done_by``.
- Row decorations: ``decoration-warning`` for *pending* and ``decoration-muted`` for *waiting*, complementing the existing ``decoration-danger`` (rejected) and ``decoration-success`` (approved). Row state is now visible at a glance.

## Screenshots

After:
<img width="2576" height="1410" alt="image" src="https://github.com/user-attachments/assets/716c6487-fff8-4f77-bde1-d9079b3f8fe8" />

<img width="2576" height="1410" alt="image" src="https://github.com/user-attachments/assets/20c49e66-5ace-4bb3-8b28-f9f2eab34685" />

New archived filter:
<img width="3925" height="321" alt="image" src="https://github.com/user-attachments/assets/272acd82-0f54-41a0-974e-568b10122cf0" />
(also displayes the new `many2one_avatar_user`  in the list view. )

## Test plan

- Open a fresh DB, install ``base_tier_validation``, install one of the bridge modules (e.g. ``account_move_tier_validation``).
- Tier Definitions menu: confirm the *Archived* filter appears next to *All*; archive a definition, click the filter, confirm it surfaces.
- Open an existing tier definition (individual reviewer): confirm the avatar appears next to the reviewer.
- Open the *Notifications & Options* tab: confirm the two columns are titled and grouped as described.
- Trigger a tier validation on a document so the Reviews table is populated; confirm row colours for each status and avatars on *Requested by* / *Done by*.

CC @LoisRForgeFlow