### PR TITLE
[19.0][IMP] base_tier_validation: name the assignee in the "to validate" banner

### DIFF
--- a/base_tier_validation/README.rst
+++ b/base_tier_validation/README.rst
@@ -125,6 +125,23 @@ improvement will be very valuable.
 Changelog
 =========
 
+19.0.1.0.4 (2026-05-13)
+-----------------------
+
+UI improvement:
+
+- The "needs to be validated" banner shown above tier-validated
+  documents now surfaces *who* is expected to act, when known. Reads
+  "Pending validation by John" or "Pending validation by Group
+  Accountants" instead of the generic "This Record needs to be
+  validated", with a fallback to the model-name phrasing for the
+  defensive edge case where no review has reached ``pending`` yet.
+  Reuses ``tier.review.todo_by`` so every review type (individual user,
+  group, ``res.users`` / ``res.groups`` field) is handled uniformly. The
+  banner template now reads from the long-standing
+  ``to_validate_message`` Html field, which was previously defined on
+  the model but never rendered.
+
 19.0.1.0.1 (2026-05-12)
 -----------------------
 

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -172,11 +172,32 @@ class TierValidation(models.AbstractModel):
         return self._description
 
     def _get_to_validate_message(self):
-        return f"""<i class="fa fa-info-circle"></i> {
-            self.env._(
-                "This %s needs to be validated", self._get_to_validate_message_name()
+        """Build the contextual "needs to be validated" banner body.
+
+        When at least one review has reached ``pending`` and carries a
+        ``todo_by`` label (i.e. the assignee is known -- a user, a group
+        or a field-based reviewer), surface it inline so the reader can
+        see at a glance *who* is expected to act next, not just *that*
+        action is needed.
+
+        Falls back to the model-name phrasing -- "This Sale Order needs
+        to be validated" -- when no pending review is available yet
+        (defensive: e.g. the ``waiting`` edge state, or downstream code
+        that calls this on a fresh record).
+        """
+        icon = '<i class="fa fa-lg fa-info-circle"></i>'
+        pending = self.review_ids.filtered(lambda r: r.status == "pending")[:1]
+        if pending and pending.todo_by:
+            return self.env._(
+                "%(icon)s Pending validation by %(todo_by)s",
+                icon=icon,
+                todo_by=pending.todo_by,
             )
-        }"""
+        return self.env._(
+            "%(icon)s This %(model_name)s needs to be validated",
+            icon=icon,
+            model_name=self._get_to_validate_message_name(),
+        )
 
     def _get_validated_message(self):
         msg = f"""<i class="fa fa-thumbs-up"></i> {
@@ -190,7 +211,7 @@ class TierValidation(models.AbstractModel):
         }"""
         return self.validation_status == "rejected" and msg or ""
 
-    @api.depends("validation_status")
+    @api.depends("validation_status", "review_ids.status", "review_ids.todo_by")
     def _compute_to_validate_message(self):
         for rec in self:
             rec.to_validate_message = rec._get_to_validate_message()

--- a/base_tier_validation/readme/HISTORY.md
+++ b/base_tier_validation/readme/HISTORY.md
@@ -1,3 +1,20 @@
+## 19.0.1.0.4 (2026-05-13)
+
+UI improvement:
+
+- The "needs to be validated" banner shown above tier-validated
+  documents now surfaces *who* is expected to act, when known.
+  Reads "Pending validation by John" or "Pending validation by
+  Group Accountants" instead of the generic
+  "This Record needs to be validated", with a fallback to the
+  model-name phrasing for the defensive edge case where no review
+  has reached ``pending`` yet. Reuses ``tier.review.todo_by`` so
+  every review type (individual user, group, ``res.users`` /
+  ``res.groups`` field) is handled uniformly. The banner template
+  now reads from the long-standing ``to_validate_message`` Html
+  field, which was previously defined on the model but never
+  rendered.
+
 ## 19.0.1.0.1 (2026-05-12)
 
 Fixes:

--- a/base_tier_validation/static/description/index.html
+++ b/base_tier_validation/static/description/index.html
@@ -398,30 +398,31 @@ compute method in <tt class="docutils literal">_get_after_validation_exceptions<
 <li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
 <li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-2">Known issues / Roadmap</a></li>
 <li><a class="reference internal" href="#changelog" id="toc-entry-3">Changelog</a><ul>
-<li><a class="reference internal" href="#section-1" id="toc-entry-4">19.0.1.0.1 (2026-05-12)</a></li>
-<li><a class="reference internal" href="#section-2" id="toc-entry-5">17.0.1.0.0 (2024-01-10)</a></li>
-<li><a class="reference internal" href="#section-3" id="toc-entry-6">14.0.1.0.0 (2020-11-19)</a></li>
-<li><a class="reference internal" href="#section-4" id="toc-entry-7">13.0.1.2.2 (2020-08-30)</a></li>
-<li><a class="reference internal" href="#section-5" id="toc-entry-8">12.0.3.3.1 (2019-12-02)</a></li>
-<li><a class="reference internal" href="#section-6" id="toc-entry-9">12.0.3.3.0 (2019-11-27)</a></li>
-<li><a class="reference internal" href="#section-7" id="toc-entry-10">12.0.3.2.1 (2019-11-26)</a></li>
-<li><a class="reference internal" href="#section-8" id="toc-entry-11">12.0.3.2.0 (2019-11-25)</a></li>
-<li><a class="reference internal" href="#section-9" id="toc-entry-12">12.0.3.1.0 (2019-07-08)</a></li>
-<li><a class="reference internal" href="#section-10" id="toc-entry-13">12.0.3.0.0 (2019-12-02)</a></li>
-<li><a class="reference internal" href="#section-11" id="toc-entry-14">12.0.2.1.0 (2019-05-29)</a></li>
-<li><a class="reference internal" href="#section-12" id="toc-entry-15">12.0.2.0.0 (2019-05-28)</a></li>
-<li><a class="reference internal" href="#section-13" id="toc-entry-16">12.0.1.0.0 (2019-02-18)</a></li>
-<li><a class="reference internal" href="#section-14" id="toc-entry-17">11.0.1.0.0 (2018-05-09)</a></li>
-<li><a class="reference internal" href="#section-15" id="toc-entry-18">10.0.1.0.0 (2018-03-26)</a></li>
-<li><a class="reference internal" href="#section-16" id="toc-entry-19">9.0.1.0.0 (2017-12-02)</a></li>
+<li><a class="reference internal" href="#section-1" id="toc-entry-4">19.0.1.0.4 (2026-05-13)</a></li>
+<li><a class="reference internal" href="#section-2" id="toc-entry-5">19.0.1.0.1 (2026-05-12)</a></li>
+<li><a class="reference internal" href="#section-3" id="toc-entry-6">17.0.1.0.0 (2024-01-10)</a></li>
+<li><a class="reference internal" href="#section-4" id="toc-entry-7">14.0.1.0.0 (2020-11-19)</a></li>
+<li><a class="reference internal" href="#section-5" id="toc-entry-8">13.0.1.2.2 (2020-08-30)</a></li>
+<li><a class="reference internal" href="#section-6" id="toc-entry-9">12.0.3.3.1 (2019-12-02)</a></li>
+<li><a class="reference internal" href="#section-7" id="toc-entry-10">12.0.3.3.0 (2019-11-27)</a></li>
+<li><a class="reference internal" href="#section-8" id="toc-entry-11">12.0.3.2.1 (2019-11-26)</a></li>
+<li><a class="reference internal" href="#section-9" id="toc-entry-12">12.0.3.2.0 (2019-11-25)</a></li>
+<li><a class="reference internal" href="#section-10" id="toc-entry-13">12.0.3.1.0 (2019-07-08)</a></li>
+<li><a class="reference internal" href="#section-11" id="toc-entry-14">12.0.3.0.0 (2019-12-02)</a></li>
+<li><a class="reference internal" href="#section-12" id="toc-entry-15">12.0.2.1.0 (2019-05-29)</a></li>
+<li><a class="reference internal" href="#section-13" id="toc-entry-16">12.0.2.0.0 (2019-05-28)</a></li>
+<li><a class="reference internal" href="#section-14" id="toc-entry-17">12.0.1.0.0 (2019-02-18)</a></li>
+<li><a class="reference internal" href="#section-15" id="toc-entry-18">11.0.1.0.0 (2018-05-09)</a></li>
+<li><a class="reference internal" href="#section-16" id="toc-entry-19">10.0.1.0.0 (2018-03-26)</a></li>
+<li><a class="reference internal" href="#section-17" id="toc-entry-20">9.0.1.0.0 (2017-12-02)</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-20">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-21">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-22">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-23">Contributors</a></li>
-<li><a class="reference internal" href="#other-credits" id="toc-entry-24">Other credits</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-25">Maintainers</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-21">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-22">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-23">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-24">Contributors</a></li>
+<li><a class="reference internal" href="#other-credits" id="toc-entry-25">Other credits</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-26">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -490,7 +491,24 @@ recurring updates that can change the expected behavior.</p>
 <div class="section" id="changelog">
 <h2><a class="toc-backref" href="#toc-entry-3">Changelog</a></h2>
 <div class="section" id="section-1">
-<h3><a class="toc-backref" href="#toc-entry-4">19.0.1.0.1 (2026-05-12)</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-4">19.0.1.0.4 (2026-05-13)</a></h3>
+<p>UI improvement:</p>
+<ul class="simple">
+<li>The “needs to be validated” banner shown above tier-validated
+documents now surfaces <em>who</em> is expected to act, when known. Reads
+“Pending validation by John” or “Pending validation by Group
+Accountants” instead of the generic “This Record needs to be
+validated”, with a fallback to the model-name phrasing for the
+defensive edge case where no review has reached <tt class="docutils literal">pending</tt> yet.
+Reuses <tt class="docutils literal">tier.review.todo_by</tt> so every review type (individual user,
+group, <tt class="docutils literal">res.users</tt> / <tt class="docutils literal">res.groups</tt> field) is handled uniformly. The
+banner template now reads from the long-standing
+<tt class="docutils literal">to_validate_message</tt> Html field, which was previously defined on
+the model but never rendered.</li>
+</ul>
+</div>
+<div class="section" id="section-2">
+<h3><a class="toc-backref" href="#toc-entry-5">19.0.1.0.1 (2026-05-12)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Restore auto-promotion of the lowest-sequence review to <tt class="docutils literal">pending</tt>
@@ -512,18 +530,18 @@ only to default subtypes; <tt class="docutils literal">message_post</tt> with th
 <tt class="docutils literal">subtype_ids</tt> explicitly (mirroring <tt class="docutils literal">_notify_review_requested</tt>).</li>
 </ul>
 </div>
-<div class="section" id="section-2">
-<h3><a class="toc-backref" href="#toc-entry-5">17.0.1.0.0 (2024-01-10)</a></h3>
+<div class="section" id="section-3">
+<h3><a class="toc-backref" href="#toc-entry-6">17.0.1.0.0 (2024-01-10)</a></h3>
 <p>Migrated to Odoo 17. Merged module with tier_validation_waiting. To
 support sending messages in a validation sequence when it is their turn
 to validate.</p>
 </div>
-<div class="section" id="section-3">
-<h3><a class="toc-backref" href="#toc-entry-6">14.0.1.0.0 (2020-11-19)</a></h3>
+<div class="section" id="section-4">
+<h3><a class="toc-backref" href="#toc-entry-7">14.0.1.0.0 (2020-11-19)</a></h3>
 <p>Migrated to Odoo 14.</p>
 </div>
-<div class="section" id="section-4">
-<h3><a class="toc-backref" href="#toc-entry-7">13.0.1.2.2 (2020-08-30)</a></h3>
+<div class="section" id="section-5">
+<h3><a class="toc-backref" href="#toc-entry-8">13.0.1.2.2 (2020-08-30)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>When using approve_sequence option in any tier.definition there can be
@@ -532,84 +550,84 @@ inconsistencies in the systray notifications</li>
 sequence, but also other sequence for the same approver</li>
 </ul>
 </div>
-<div class="section" id="section-5">
-<h3><a class="toc-backref" href="#toc-entry-8">12.0.3.3.1 (2019-12-02)</a></h3>
+<div class="section" id="section-6">
+<h3><a class="toc-backref" href="#toc-entry-9">12.0.3.3.1 (2019-12-02)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Show comment on Reviews Table.</li>
 <li>Edit notification with approve_sequence.</li>
 </ul>
 </div>
-<div class="section" id="section-6">
-<h3><a class="toc-backref" href="#toc-entry-9">12.0.3.3.0 (2019-11-27)</a></h3>
+<div class="section" id="section-7">
+<h3><a class="toc-backref" href="#toc-entry-10">12.0.3.3.0 (2019-11-27)</a></h3>
 <p>New features:</p>
 <ul class="simple">
 <li>Add comment on Reviews Table.</li>
 <li>Approve by sequence.</li>
 </ul>
 </div>
-<div class="section" id="section-7">
-<h3><a class="toc-backref" href="#toc-entry-10">12.0.3.2.1 (2019-11-26)</a></h3>
+<div class="section" id="section-8">
+<h3><a class="toc-backref" href="#toc-entry-11">12.0.3.2.1 (2019-11-26)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Remove message_subscribe_users</li>
 </ul>
 </div>
-<div class="section" id="section-8">
-<h3><a class="toc-backref" href="#toc-entry-11">12.0.3.2.0 (2019-11-25)</a></h3>
+<div class="section" id="section-9">
+<h3><a class="toc-backref" href="#toc-entry-12">12.0.3.2.0 (2019-11-25)</a></h3>
 <p>New features:</p>
 <ul class="simple">
 <li>Notify reviewers</li>
 </ul>
 </div>
-<div class="section" id="section-9">
-<h3><a class="toc-backref" href="#toc-entry-12">12.0.3.1.0 (2019-07-08)</a></h3>
+<div class="section" id="section-10">
+<h3><a class="toc-backref" href="#toc-entry-13">12.0.3.1.0 (2019-07-08)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Singleton error</li>
 </ul>
 </div>
-<div class="section" id="section-10">
-<h3><a class="toc-backref" href="#toc-entry-13">12.0.3.0.0 (2019-12-02)</a></h3>
+<div class="section" id="section-11">
+<h3><a class="toc-backref" href="#toc-entry-14">12.0.3.0.0 (2019-12-02)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Edit Reviews Table</li>
 </ul>
 </div>
-<div class="section" id="section-11">
-<h3><a class="toc-backref" href="#toc-entry-14">12.0.2.1.0 (2019-05-29)</a></h3>
+<div class="section" id="section-12">
+<h3><a class="toc-backref" href="#toc-entry-15">12.0.2.1.0 (2019-05-29)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Edit drop-down style width and position</li>
 </ul>
 </div>
-<div class="section" id="section-12">
-<h3><a class="toc-backref" href="#toc-entry-15">12.0.2.0.0 (2019-05-28)</a></h3>
+<div class="section" id="section-13">
+<h3><a class="toc-backref" href="#toc-entry-16">12.0.2.0.0 (2019-05-28)</a></h3>
 <p>New features:</p>
 <ul class="simple">
 <li>Pass parameters as functions.</li>
 <li>Add Systray.</li>
 </ul>
 </div>
-<div class="section" id="section-13">
-<h3><a class="toc-backref" href="#toc-entry-16">12.0.1.0.0 (2019-02-18)</a></h3>
+<div class="section" id="section-14">
+<h3><a class="toc-backref" href="#toc-entry-17">12.0.1.0.0 (2019-02-18)</a></h3>
 <p>Migrated to Odoo 12.</p>
 </div>
-<div class="section" id="section-14">
-<h3><a class="toc-backref" href="#toc-entry-17">11.0.1.0.0 (2018-05-09)</a></h3>
+<div class="section" id="section-15">
+<h3><a class="toc-backref" href="#toc-entry-18">11.0.1.0.0 (2018-05-09)</a></h3>
 <p>Migrated to Odoo 11.</p>
 </div>
-<div class="section" id="section-15">
-<h3><a class="toc-backref" href="#toc-entry-18">10.0.1.0.0 (2018-03-26)</a></h3>
+<div class="section" id="section-16">
+<h3><a class="toc-backref" href="#toc-entry-19">10.0.1.0.0 (2018-03-26)</a></h3>
 <p>Migrated to Odoo 10.</p>
 </div>
-<div class="section" id="section-16">
-<h3><a class="toc-backref" href="#toc-entry-19">9.0.1.0.0 (2017-12-02)</a></h3>
+<div class="section" id="section-17">
+<h3><a class="toc-backref" href="#toc-entry-20">9.0.1.0.0 (2017-12-02)</a></h3>
 <p>First version.</p>
 </div>
 </div>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#toc-entry-20">Bug Tracker</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-21">Bug Tracker</a></h2>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/tier-validation/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -617,15 +635,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#toc-entry-21">Credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-22">Credits</a></h2>
 <div class="section" id="authors">
-<h3><a class="toc-backref" href="#toc-entry-22">Authors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-23">Authors</a></h3>
 <ul class="simple">
 <li>ForgeFlow</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h3><a class="toc-backref" href="#toc-entry-23">Contributors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-24">Contributors</a></h3>
 <ul class="simple">
 <li>Lois Rilo &lt;<a class="reference external" href="mailto:lois.rilo&#64;forgeflow.com">lois.rilo&#64;forgeflow.com</a>&gt;</li>
 <li>Naglis Jonaitis &lt;<a class="reference external" href="mailto:naglis&#64;versada.eu">naglis&#64;versada.eu</a>&gt;</li>
@@ -650,10 +668,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="other-credits">
-<h3><a class="toc-backref" href="#toc-entry-24">Other credits</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-25">Other credits</a></h3>
 </div>
 <div class="section" id="maintainers">
-<h3><a class="toc-backref" href="#toc-entry-25">Maintainers</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-26">Maintainers</a></h3>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/base_tier_validation/templates/tier_validation_templates.xml
+++ b/base_tier_validation/templates/tier_validation_templates.xml
@@ -25,27 +25,31 @@
                 t-attf-invisible="validation_status == 'validated' or hide_reviews or validation_status == 'rejected' or not review_ids"
             >
                 <p class="mb-1">
-                <i class="fa fa-lg fa-info-circle" />
-                This Record needs to be
-                validated.
-                <button
-                    name="validate_tier"
-                    string="Validate"
-                    invisible="not can_review"
-                    type="object"
-                    class="btn-icon me-1 btn-success"
-                    icon="fa-thumbs-up"
-                />
-                <button
-                    name="reject_tier"
-                    string="Reject"
-                    invisible="not can_review"
-                    type="object"
-                    class="btn-icon btn-danger"
-                    icon="fa-thumbs-down"
-                />
-                <br /><field name="next_review" readonly="1" />
-            </p>
+                    <field
+                        name="to_validate_message"
+                        readonly="1"
+                        nolabel="1"
+                        widget="html"
+                    />
+                    <button
+                        name="validate_tier"
+                        string="Validate"
+                        invisible="not can_review"
+                        type="object"
+                        class="btn-icon me-1 btn-success"
+                        icon="fa-thumbs-up"
+                    />
+                    <button
+                        name="reject_tier"
+                        string="Reject"
+                        invisible="not can_review"
+                        type="object"
+                        class="btn-icon btn-danger"
+                        icon="fa-thumbs-down"
+                    />
+                    <br />
+                    <field name="next_review" readonly="1" />
+                </p>
             </div>
             <div
                 class="alert alert-success mb-0"

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -718,6 +718,55 @@ class TierTierValidation(CommonTierValidation):
         self.assertEqual(test_record.message_follower_ids, followers_before)
         self.assertEqual(test_record.message_ids, messages_before)
 
+    def test_19c_to_validate_message_names_assignee(self):
+        """The ``to_validate_message`` Html field -- which the banner
+        template renders above the document -- must surface *who* the
+        record is pending on (using ``tier.review.todo_by``) rather
+        than the generic "This Record needs to be validated".
+        """
+        # Use a value that matches only the common.py definition_3 (sequence
+        # 10, reviewer test_user_2) -- and definition_2 (sequence 20,
+        # reviewer test_user_1). After ``_update_review_status`` only the
+        # lowest-sequence review is promoted to ``pending``.
+        test_record = self.test_model.create({"test_field": 3.5})
+        reviews = test_record.request_validation()
+        self.assertTrue(reviews)
+        # Manually promote (since common.py's test_user_1 is not the
+        # requester, request_validation in 19.0 leaves the reviews in
+        # ``waiting`` unless ``notify_on_create`` triggers it).
+        reviews._update_review_status()
+        pending = reviews.filtered(lambda r: r.status == "pending")
+        self.assertEqual(len(pending), 1)
+        test_record.invalidate_recordset(["to_validate_message"])
+        msg = test_record.to_validate_message or ""
+        # The banner must name the pending assignee...
+        self.assertIn(pending.todo_by, msg)
+        # ...and must not fall back to the generic record-name phrasing.
+        self.assertNotIn("needs to be validated", msg)
+
+    def test_19d_to_validate_message_falls_back_when_no_pending(self):
+        """When no review has reached ``pending`` (e.g. the defensive
+        ``waiting`` edge case), the banner must fall back to the
+        model-name phrasing so the document still has something useful.
+        """
+        # Force-create a review row directly and leave it ``waiting`` so
+        # the pending filter is empty. (``request_validation`` would
+        # auto-promote one in normal flow.)
+        test_record = self.test_model.create({"test_field": 3.5})
+        self.env["tier.review"].create(
+            {
+                "model": self.test_model._name,
+                "res_id": test_record.id,
+                "definition_id": self.definition_2.id,
+                "sequence": 1,
+                "status": "waiting",
+            }
+        )
+        test_record.invalidate_recordset(["to_validate_message"])
+        msg = test_record.to_validate_message or ""
+        self.assertIn("needs to be validated", msg)
+        self.assertIn(self.test_model._description, msg)
+
     def test_20_no_sequence(self):
         # Create new test record
         tier_review_obj = self.env["tier.review"]


### PR DESCRIPTION
## What

The yellow banner shown above a tier-validated document currently reads

> *This Record needs to be validated.*

…which is generic in two ways: it does not say which model the record belongs to, and -- more importantly -- it does not say **who** is expected to act. Users in our rollout consistently asked "who's holding this up?" even though that information already exists on ``tier.review.todo_by``.

This PR makes the banner read, for example:

> *Pending validation by John*
> *Pending validation by Group Accountants*
> *Pending validation by Mike, Jane (and 2 more)*

…sourced from the same ``todo_by`` the Reviews table already uses, so individual users, groups, ``res.users`` / ``res.groups`` field reviewers and Python-expression reviewers all render uniformly.

When no review has yet reached ``pending`` (defensive edge case -- e.g. ``waiting`` state, or downstream code that calls the method on a fresh record), the banner falls back to the existing model-name phrasing:

> *This Sale Order needs to be validated.*

## Plumbing

- ``_get_to_validate_message`` now picks the lowest-sequence pending review and embeds its ``todo_by`` into the body.
- ``_compute_to_validate_message`` now depends on ``review_ids.status`` and ``review_ids.todo_by`` in addition to ``validation_status``, so the banner refreshes when a tier is promoted or when the assignee changes.
- The ``tier_validation_label`` template now actually renders the ``to_validate_message`` Html field (which has existed on the abstract model since v14 but was never wired into the template; the template carried its own hardcoded text).

## Tests

- ``test_19c_to_validate_message_names_assignee`` -- after a tier reaches ``pending``, the banner contains the assignee and does not contain the generic phrasing.
- ``test_19d_to_validate_message_falls_back_when_no_pending`` -- with no pending review on the record, the banner falls back to the model-name phrasing.

## Notes

- Independent of #21, #22, and #23 -- no overlap. Touches model + template + tests only.
- ``_get_to_validate_message_name`` is unchanged and still hooks any downstream override (custom phrasing per model). The new code only changes what's rendered when ``todo_by`` is available.
- ``next_review`` (the "Next: <definition name>" sub-line) is left as-is. It's complementary information -- the new banner says *who*, ``next_review`` says *which tier*. Removing it is out of scope.

CC @LoisRForgeFlow