### PR TITLE
[19.0][IMP] base_tier_validation_correction: UI polish

### DIFF
--- a/base_tier_validation_correction/__manifest__.py
+++ b/base_tier_validation_correction/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Base Tier Validation Correction",
     "summary": "Correct tier.review data after it has been created.",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.1.0",
     "category": "Tools",
     "website": "https://github.com/OCA/tier-validation",
     "author": "Ecosoft,Odoo Community Association (OCA)",

--- a/base_tier_validation_correction/__manifest__.py
+++ b/base_tier_validation_correction/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Base Tier Validation Correction",
     "summary": "Correct tier.review data after it has been created.",
-    "version": "19.0.1.1.0",
+    "version": "19.0.1.0.0",
     "category": "Tools",
     "website": "https://github.com/OCA/tier-validation",
     "author": "Ecosoft,Odoo Community Association (OCA)",

--- a/base_tier_validation_correction/views/tier_correction_view.xml
+++ b/base_tier_validation_correction/views/tier_correction_view.xml
@@ -18,7 +18,7 @@
                     decoration-info="state == 'draft'"
                     decoration-warning="state == 'prepare'"
                     decoration-success="state == 'done'"
-                    decoration-danger="state in 'cancel'"
+                    decoration-danger="state in ['cancel', 'revert']"
                     widget="badge"
                 />
             </list>
@@ -41,7 +41,7 @@
                         name="action_done"
                         invisible="state != 'prepare'"
                         type="object"
-                        string="Make Correcton"
+                        string="Make Correction"
                         class="oe_highlight"
                         confirm="Are you sure to reassign new reviewer(s) for affected tier reviews?"
                     />
@@ -73,7 +73,6 @@
                 <sheet>
                     <div class="oe_button_box" name="button_box" />
                     <div class="oe_title">
-                        <span class="oe_edit_only">Name</span>
                         <h1>
                             <field
                                 name="name"
@@ -106,7 +105,7 @@
                             name="search"
                             string="Find documents with pending reviews by"
                         >
-                            <p class="oe_grey" colspan="2">
+                            <p class="text-muted" colspan="2">
                                 This is optional search criteria to find matched document into Correction Details.
                                 Only document with pending reviews will be listed.
                             </p>
@@ -119,7 +118,7 @@
                             <field name="search_name" readonly="state != 'draft'" />
                         </group>
                         <group name="set_value" string="Reassign to new value">
-                            <p class="oe_grey" colspan="2">
+                            <p class="text-muted" colspan="2">
                                 Default new reviewers to be assigned to the correction. This value can be overwritten in
                                 Correction Detail.
                             </p>
@@ -171,7 +170,7 @@
                             </field>
                         </page>
                         <page string="Scheduled Action">
-                            <div class="oe_grey" colspan="4">
+                            <div class="text-muted" colspan="4">
                                 Scheduled date/time to auto correct and/or revert by
                                 <button
                                 name="%(view_affected_tier_reviews_action)d"

--- a/base_tier_validation_correction/views/tier_correction_view.xml
+++ b/base_tier_validation_correction/views/tier_correction_view.xml
@@ -9,7 +9,10 @@
             <list>
                 <field name="name" />
                 <field name="correction_type" />
+                <field name="model_id" />
                 <field name="reference" />
+                <field name="create_uid" widget="many2one_avatar_user" />
+                <field name="create_date" optional="show" />
                 <field
                     name="state"
                     decoration-info="state == 'draft'"
@@ -92,7 +95,11 @@
                             <field name="model" invisible="1" />
                         </group>
                         <group>
-                            <field name="create_uid" readonly="1" />
+                            <field
+                                name="create_uid"
+                                readonly="1"
+                                widget="many2one_avatar_user"
+                            />
                             <field name="create_date" readonly="1" />
                         </group>
                         <group
@@ -106,7 +113,7 @@
                             <field
                                 name="old_reviewer_ids"
                                 readonly="state != 'draft'"
-                                widget="many2many_tags"
+                                widget="many2many_avatar_user"
                                 string="Reviewer(s)"
                             />
                             <field name="search_name" readonly="state != 'draft'" />
@@ -119,7 +126,7 @@
                             <field
                                 name="new_reviewer_ids"
                                 readonly="state != 'draft'"
-                                widget="many2many_tags"
+                                widget="many2many_avatar_user"
                                 string="Reviewer(s)"
                                 invisible="correction_type != 'reviewer'"
                                 required="correction_type == 'reviewer'"
@@ -136,7 +143,7 @@
                                     <field name="resource_ref" />
                                     <field
                                         name="new_reviewer_ids"
-                                        widget="many2many_tags"
+                                        widget="many2many_avatar_user"
                                     />
                                     <field name="review_ids" widget="many2many_tags" />
                                     <button
@@ -153,7 +160,7 @@
                                     <group>
                                         <field
                                             name="new_reviewer_ids"
-                                            widget="many2many_tags"
+                                            widget="many2many_avatar_user"
                                         />
                                         <field
                                             name="review_ids"
@@ -225,22 +232,60 @@
                     string="Reviewer"
                     filter_domain="['|', ('old_reviewer_ids', 'ilike', self), ('new_reviewer_ids', 'ilike', self)]"
                 />
+                <field name="model_id" />
+                <filter
+                    string="My Corrections"
+                    name="my_corrections"
+                    domain="[('create_uid', '=', uid)]"
+                />
                 <separator />
                 <filter
                     string="Change Reviewers"
                     name="reviewer"
                     domain="[('correction_type', '=', 'reviewer')]"
                 />
+                <separator />
+                <filter
+                    string="Draft"
+                    name="state_draft"
+                    domain="[('state', '=', 'draft')]"
+                />
+                <filter
+                    string="Preparing"
+                    name="state_prepare"
+                    domain="[('state', '=', 'prepare')]"
+                />
+                <filter
+                    string="Corrected"
+                    name="state_done"
+                    domain="[('state', '=', 'done')]"
+                />
+                <filter
+                    string="Cancelled"
+                    name="state_cancel"
+                    domain="[('state', '=', 'cancel')]"
+                />
+                <filter
+                    string="Reverted"
+                    name="state_revert"
+                    domain="[('state', '=', 'revert')]"
+                />
                 <group>
                     <filter
+                        string="Status"
+                        name="group_state"
+                        domain="[]"
+                        context="{'group_by':'state'}"
+                    />
+                    <filter
                         string="Correction Type"
-                        name="correction_type"
+                        name="group_correction_type"
                         domain="[]"
                         context="{'group_by':'correction_type'}"
                     />
                     <filter
                         string="Model"
-                        name="correction_type"
+                        name="group_model"
                         domain="[]"
                         context="{'group_by':'model_id'}"
                     />
@@ -253,7 +298,7 @@
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">tier.correction</field>
         <field name="view_mode">list,form</field>
-        <field name="context">{}</field>
+        <field name="context">{'search_default_group_state': 1}</field>
     </record>
     <menuitem
         id="menu_tier_correction"


### PR DESCRIPTION
## Summary

UI improvements for the `tier.correction` views.

- Apply `many2many_avatar_user` to `old_reviewer_ids` / `new_reviewer_ids` (form view, items inline list and form).
- Apply `many2one_avatar_user` to `create_uid` (form view and list view).
- Add the **Model** column to the list view, plus `create_uid` (avatar) and `create_date`.
- Search view:
  - Add `model_id` searchable field.
  - Add **My Corrections** filter (`create_uid = uid`).
  - Add per-state filters: Draft / Preparing / Corrected / Cancelled / Reverted.
  - Add **Status** groupby and set it as the default via the action context.
- Fix bug: the search view declared two `<filter name="correction_type">`. The duplicate name caused the **Model** groupby to shadow the **Correction Type** one. Renamed to `group_state` / `group_correction_type` / `group_model`.

## Test plan

- [ ] Open *Tier Review Correction*: list view groups by Status by default and shows Model, Created by (avatar) and Creation Date.
- [ ] Open a record: reviewer fields show user avatars in both the main form groups and the *Correction Details* inline list.
- [ ] In the search view, both "Correction Type" and "Model" groupby filters work independently.
- [ ] The "My Corrections" filter restricts to records created by the current user.
- [ ] The per-state filters each show the matching records.