### PR TITLE
[19.0][IMP] base_tier_validation_formula: code widget on python expressions

### DIFF
--- a/base_tier_validation_formula/views/tier_definition_view.xml
+++ b/base_tier_validation_formula/views/tier_definition_view.xml
@@ -12,6 +12,9 @@
                     <field
                         name="reviewer_expression"
                         colspan="4"
+                        widget="code"
+                        options="{'mode': 'python'}"
+                        placeholder="# Available locals:&#10;#  - rec: current record&#10;#  - Expects a recordset of res.users&#10;rec.env.user"
                         invisible="review_type != 'expression'"
                     />
                 </group>
@@ -21,14 +24,18 @@
                     name="invisible"
                 >definition_type not in ('domain', 'domain_formula')</attribute>
             </xpath>
-            <field name="definition_domain" position="after">
-                <field
-                    name="python_code"
-                    widget="code"
-                    options="{'mode': 'python'}"
-                    invisible="definition_type not in ('formula', 'domain_formula')"
-                />
-            </field>
+            <xpath expr="//page[@name='apply']/group[@name='bottom']" position="after">
+                <group col="4">
+                    <field
+                        name="python_code"
+                        colspan="4"
+                        widget="code"
+                        options="{'mode': 'python'}"
+                        placeholder="# Available locals:&#10;#  - rec: current record&#10;True"
+                        invisible="definition_type not in ('formula', 'domain_formula')"
+                    />
+                </group>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
## Summary

- Apply `widget="code"` with `options="{'mode': 'python'}"` to `reviewer_expression`, so the Python Expression reviewer field gets the same syntax-highlighted editor as `python_code`.
- Move `python_code` into its own full-width group (`col="4"` / `colspan="4"`) so the code editor is no longer squeezed to half-width inside the default 2-column *Apply On* group.
- Add `placeholder` hints on both fields listing the available locals (`rec`, expected return type) for the first time a user clears the default.

## Test plan

- [ ] Open a `tier.definition` record, set Review Type = *Python Expression*: the *Review Expression* field renders with the code widget (syntax highlighting, monospace) and takes full sheet width.
- [ ] Set Definition Type = *Formula* or *Domain & Formula*: the *Tier Definition Expression* field is shown in a full-width code editor.
- [ ] Clear each expression: the placeholder lists the available locals.
- [ ] Switch Review/Definition Type back to a non-expression value: the fields hide as before.


Before:
<img width="2042" height="747" alt="image" src="https://github.com/user-attachments/assets/ac5b466d-27aa-425b-a3d4-5d93e2ff8d40" />


After:
<img width="2042" height="747" alt="image" src="https://github.com/user-attachments/assets/8122f676-4a55-4218-b285-0ca19a698fdb" />
