### PR TITLE
[19.0][ADD] base_tier_validation_correction: kanban view grouped by state

### DIFF
--- a/base_tier_validation_correction/views/tier_correction_view.xml
+++ b/base_tier_validation_correction/views/tier_correction_view.xml
@@ -248,11 +248,47 @@
             </search>
         </field>
     </record>
+    <record id="tier_correction_view_kanban" model="ir.ui.view">
+        <field name="name">tier.correction.kanban</field>
+        <field name="model">tier.correction</field>
+        <field name="arch" type="xml">
+            <kanban default_group_by="state" group_create="0" group_delete="0">
+                <field name="name" />
+                <field name="correction_type" />
+                <field name="model_id" />
+                <field name="create_uid" />
+                <field name="state" />
+                <templates>
+                    <t t-name="card">
+                        <div class="oe_kanban_global_click">
+                            <div class="o_kanban_record_top">
+                                <div class="o_kanban_record_headings">
+                                    <strong class="o_kanban_record_title">
+                                        <field name="name" />
+                                    </strong>
+                                    <small class="o_kanban_record_subtitle text-muted">
+                                        <field name="model_id" />
+                                    </small>
+                                </div>
+                                <field
+                                    name="create_uid"
+                                    widget="many2one_avatar_user"
+                                />
+                            </div>
+                            <div class="o_kanban_record_body">
+                                <field name="correction_type" />
+                            </div>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
     <record id="tier_correction_action" model="ir.actions.act_window">
         <field name="name">Tier Review Correction</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">tier.correction</field>
-        <field name="view_mode">list,form</field>
+        <field name="view_mode">kanban,list,form</field>
         <field name="context">{}</field>
     </record>
     <menuitem


### PR DESCRIPTION
> **Draft** — opened for discussion. Not for merge until the maintainers signal interest in a kanban view for this model.

## Summary

Add a kanban view to `tier.correction` with `default_group_by="state"`, giving a visual board view of the workflow:

`draft` -> `prepare` -> `done` -> `cancel` / `revert`

The kanban becomes the first view on the action so users land on the board when opening the menu (list and form still available).

Each card shows:

- the description (`name`) as the title,
- the target `model_id` as a subtitle,
- the creator avatar (`many2one_avatar_user`) in the top-right,
- the `correction_type` in the card body.

`group_create="0" group_delete="0"` so the fixed `state` Selection can't be turned into ad-hoc folders.

## Why a draft

A kanban view is a real UI commitment: it's the entry point users will see first. Wanted to put it up for the maintainers to nod or push back on before polishing further (extra fields on the cards, decorations on the column titles, etc.).

## Test plan

- Install / upgrade `base_tier_validation_correction`.
- Open *Tier Review Correction* menu: kanban opens by default, with columns for Draft / Preparing / Corrected / Cancelled / Reverted.
- Create one record of each state: each card appears in the right column with the model, correction type, and the creator avatar visible.