### PR TITLE
[19.0][FIX] base_tier_validation: AccessError in systray when reviewer lacks model ACL

### DIFF
--- a/base_tier_validation/__manifest__.py
+++ b/base_tier_validation/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Base Tier Validation",
     "summary": "Implement a validation process based on tiers.",
-    "version": "19.0.1.0.2",
+    "version": "19.0.1.0.3",
     "development_status": "Mature",
     "maintainers": ["LoisRForgeFlow"],
     "category": "Tools",

--- a/base_tier_validation/models/res_users.py
+++ b/base_tier_validation/models/res_users.py
@@ -1,8 +1,13 @@
 # Copyright 2019 ForgeFlow S.L. (https://www.forgeflow.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+import logging
+
 from odoo import api, fields, models, modules
+from odoo.exceptions import AccessError
 from odoo.fields import Domain
+
+_logger = logging.getLogger(__name__)
 
 
 class Users(models.Model):
@@ -36,11 +41,25 @@ class Users(models.Model):
                     & Domain("validation_status", "!=", "rejected")
                     & Domain("can_review", "=", True)
                 )
-                records = (
-                    Model.with_user(user)
-                    .with_context(active_test=False)
-                    .search(records_domain)
-                )
+                try:
+                    records = (
+                        Model.with_user(user)
+                        .with_context(active_test=False)
+                        .search(records_domain)
+                    )
+                except AccessError:
+                    # The user is a reviewer on records of a model whose
+                    # ir.model.access does not grant them read access (e.g.
+                    # a tier definition pointing at account.move while the
+                    # reviewer has no accounting group). Skip silently so
+                    # the systray keeps working; the reviewer cannot act on
+                    # these reviews anyway without read access.
+                    _logger.debug(
+                        "User %s has no read access to %s; skipping in systray.",
+                        user.login,
+                        model,
+                    )
+                    continue
                 # Excludes any cancelled records depending on the structure of the model
                 if Model._state_field in Model._fields:
                     records = records.filtered(

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -7,7 +7,7 @@ from unittest import mock
 from lxml import etree
 
 from odoo import Command
-from odoo.exceptions import ValidationError
+from odoo.exceptions import AccessError, ValidationError
 from odoo.fields import Domain
 from odoo.tests import Form
 from odoo.tests.common import tagged
@@ -507,6 +507,34 @@ class TierTierValidation(CommonTierValidation):
         self.assertFalse(
             self.test_user_2.with_user(self.test_user_2).review_user_count()
         )
+
+    def test_16b_review_user_count_no_model_access(self):
+        """Reviewer without ir.model.access read on the validated model must
+        not crash the systray endpoint. Regression: the systray called
+        Model.with_user(user).search(...) which raises AccessError when the
+        user has no read access (e.g. tier definition on account.move for a
+        non-accounting user)."""
+        test_record = self.test_model.create({"test_field": 2.5})
+        self.tier_def_obj.create(
+            {
+                "model_id": self.tester_model.id,
+                "review_type": "individual",
+                "reviewer_id": self.test_user_2.id,
+                "definition_domain": "[('test_field', '>', 1.0)]",
+            }
+        )
+        test_record.with_user(self.test_user_1).request_validation()
+        self.assertTrue(self.test_user_2.review_ids)
+        # Revoke read access on the validated model for non-superadmin users.
+        self.env["ir.model.access"].search(
+            Domain("model_id", "=", self.tester_model.id)
+        ).unlink()
+        # Sanity check: a direct search now raises AccessError.
+        with self.assertRaises(AccessError):
+            self.test_model.with_user(self.test_user_2).search([])
+        # The systray endpoint must swallow that error and return [].
+        result = self.test_user_2.with_user(self.test_user_2).review_user_count()
+        self.assertEqual(result, [])
 
     def test_17_search_records_no_validation(self):
         """Search for records that have no validation process started"""


### PR DESCRIPTION
## Summary

The reviewer systray endpoint `res.users.review_user_count()` iterates the current user's pending tier reviews, groups them by model, and for each model does:

```python
records = (
    Model.with_user(user)
    .with_context(active_test=False)
    .search(records_domain)
)
```

When the user is a reviewer on a model they have no `ir.model.access` read on (e.g. a tier definition on `account.move` assigned to a non-accounting user), that `search()` raises `AccessError`. Because the systray fetches the count on every component mount, every page refresh in that user's session crashes with:

> You are not allowed to access 'Journal Entry' (account.move) records.

## Repro on runboat

1. As admin: create a tier definition on `account.move` with the demo user as reviewer.
2. Log in as demo in another browser.
3. As admin: request validation on a journal entry.
4. Refresh demo's browser → AccessError on every page.

## Fix

Catch `AccessError` per model inside the loop and skip silently (debug log). The user can't act on records they have no read access to anyway, so the right behaviour is to drop the model from the count rather than crash the whole systray.

## Test plan

- Run the new `test_16b_review_user_count_no_model_access`: it unlinks the tester model's `ir.model.access`, requests validation, and asserts `review_user_count()` returns `[]` (was raising `AccessError` before).
- On runboat: install a fresh DB, follow the reproduction steps above. Before the fix every refresh blew up; after, the systray shows no count (or shows counts only for models the user can read) and the page loads.