### PR TITLE
[19.0][FIX] base_tier_validation_correction: restrict resource_ref to tier-validated models

### DIFF
--- a/base_tier_validation_correction/__manifest__.py
+++ b/base_tier_validation_correction/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Base Tier Validation Correction",
     "summary": "Correct tier.review data after it has been created.",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "category": "Tools",
     "website": "https://github.com/OCA/tier-validation",
     "author": "Ecosoft,Odoo Community Association (OCA)",

--- a/base_tier_validation_correction/__manifest__.py
+++ b/base_tier_validation_correction/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Base Tier Validation Correction",
     "summary": "Correct tier.review data after it has been created.",
-    "version": "19.0.1.0.1",
+    "version": "19.0.1.0.0",
     "category": "Tools",
     "website": "https://github.com/OCA/tier-validation",
     "author": "Ecosoft,Odoo Community Association (OCA)",

--- a/base_tier_validation_correction/models/tier_correction_item.py
+++ b/base_tier_validation_correction/models/tier_correction_item.py
@@ -17,7 +17,18 @@ class TierCorrectionItem(models.Model):
     resource_ref = fields.Reference(
         string="Resource",
         selection=lambda self: [
-            (model.model, model.name) for model in self.env["ir.model"].search([])
+            (model.model, model.name)
+            for model in self.env["ir.model"].search(
+                [
+                    (
+                        "model",
+                        "in",
+                        self.env[
+                            "tier.definition"
+                        ]._get_tier_validation_model_names(),
+                    )
+                ]
+            )
         ],
         readonly=True,
     )

--- a/base_tier_validation_correction/models/tier_correction_item.py
+++ b/base_tier_validation_correction/models/tier_correction_item.py
@@ -23,9 +23,7 @@ class TierCorrectionItem(models.Model):
                     (
                         "model",
                         "in",
-                        self.env[
-                            "tier.definition"
-                        ]._get_tier_validation_model_names(),
+                        self.env["tier.definition"]._get_tier_validation_model_names(),
                     )
                 ]
             )


### PR DESCRIPTION
## Summary

The `resource_ref` Reference field on `tier.correction.item` listed **every** `ir.model` in its selection callback. Two problems:

- **Performance**: the callback ran `self.env["ir.model"].search([])` and built ~500 tuples per dropdown render. Noticeable stall on installations with many custom modules.
- **Correctness / UX**: the dropdown surfaced models that can't have tier reviews (res.partner, res.country, ...), letting an admin reference a record on a model where no correction is meaningful.

Restrict the selection to the same model set the `tier.correction` form already uses for its `model_id` Many2one — `tier.definition._get_tier_validation_model_names()`. Picker now only offers models that actually support tier validation; the underlying query is bounded to that set.

## Test plan

- Open a `tier.correction.item` form. The *Resource* reference dropdown now only includes models that have a `tier.definition` (e.g. `account.move` when `account_move_tier_validation` is installed), not every model in the system.
- Performance: the ir.model query result set shrinks from ~all models to typically <10. Visible difference on installations with many addons.