### PR TITLE
[19.0][FIX] base_tier_validation: bypass approval only for consecutive tiers

### DIFF
--- a/base_tier_validation/__manifest__.py
+++ b/base_tier_validation/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Base Tier Validation",
     "summary": "Implement a validation process based on tiers.",
-    "version": "19.0.1.0.2",
+    "version": "19.0.1.0.3",
     "development_status": "Mature",
     "maintainers": ["LoisRForgeFlow"],
     "category": "Tools",

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -531,9 +531,19 @@ class TierValidation(models.AbstractModel):
                 }
             )
 
-        user_reviews = tier_reviews.filtered(
-            lambda r: r.status == "pending" and (self.env.user in r.reviewer_ids)
+        # Only approve consecutive pending reviews (by sequence) for the
+        # current user. Stop at the first review not assigned to the user,
+        # so intermediate reviewers are not skipped.
+        sorted_pending = tier_reviews.filtered(lambda r: r.status == "pending").sorted(
+            "sequence"
         )
+        user_reviews = self.env["tier.review"]
+        for review in sorted_pending:
+            if self.env.user in review.reviewer_ids:
+                user_reviews |= review
+            else:
+                break
+
         user_reviews.write(
             {
                 "status": "approved",

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -552,9 +552,19 @@ class TierValidation(models.AbstractModel):
                 }
             )
 
-        user_reviews = tier_reviews.filtered(
-            lambda r: r.status == "pending" and (self.env.user in r.reviewer_ids)
+        # Only approve consecutive pending reviews (by sequence) for the
+        # current user. Stop at the first review not assigned to the user,
+        # so intermediate reviewers are not skipped.
+        sorted_pending = tier_reviews.filtered(lambda r: r.status == "pending").sorted(
+            "sequence"
         )
+        user_reviews = self.env["tier.review"]
+        for review in sorted_pending:
+            if self.env.user in review.reviewer_ids:
+                user_reviews |= review
+            else:
+                break
+
         user_reviews.write(
             {
                 "status": "approved",

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -365,10 +365,14 @@ class TierTierValidation(CommonTierValidation):
 
     def test_12_approve_sequence_same_user_bypassed(self):
         """Similar to test_12_approve_sequence, with all same users,
-        but approve_sequence_bypass is True"""
+        but approve_sequence_bypass is True
+        Sequence of reviewers: A, A, B, A.
+        When A validates, it should only validate the first two (A, A) and stop at B.
+        """
         # Create new test record
         test_record = self.test_model.create({"test_field": 2.5})
         # Create tier definitions
+        # sequence 40 (User 1)
         self.tier_def_obj.create(
             {
                 "model_id": self.tester_model.id,
@@ -377,9 +381,34 @@ class TierTierValidation(CommonTierValidation):
                 "definition_domain": "[('test_field', '>', 1.0)]",
                 "approve_sequence": True,
                 "approve_sequence_bypass": True,
+                "sequence": 40,
+            }
+        )
+        # sequence 30 (User 1)
+        self.tier_def_obj.create(
+            {
+                "model_id": self.tester_model.id,
+                "review_type": "individual",
+                "reviewer_id": self.test_user_1.id,
+                "definition_domain": "[('test_field', '>', 1.0)]",
+                "approve_sequence": True,
+                "approve_sequence_bypass": True,
+                "sequence": 30,
+            }
+        )
+        # sequence 20 (User 2)
+        self.tier_def_obj.create(
+            {
+                "model_id": self.tester_model.id,
+                "review_type": "individual",
+                "reviewer_id": self.test_user_2.id,
+                "definition_domain": "[('test_field', '>', 1.0)]",
+                "approve_sequence": True,
+                "approve_sequence_bypass": True,
                 "sequence": 20,
             }
         )
+        # sequence 10 (User 1)
         self.tier_def_obj.create(
             {
                 "model_id": self.tester_model.id,
@@ -399,13 +428,41 @@ class TierTierValidation(CommonTierValidation):
         record1 = test_record.with_user(self.test_user_1.id)
         self.assertTrue(record1.can_review)
         # When the first tier is validated, all the rest will be approved.
-        self.assertEqual(len(record1.review_ids), 2)
+        self.assertEqual(len(record1.review_ids), 4)
         self.assertEqual(
-            1, len(record1.review_ids.filtered(lambda x: x.status == "waiting"))
+            3, len(record1.review_ids.filtered(lambda x: x.status == "waiting"))
         )
         self.assertEqual(
             1, len(record1.review_ids.filtered(lambda x: x.status == "pending"))
         )
+        record1.validate_tier()
+        # After user 1 validates, they should have approved exactly 2 tiers: 40 and 30
+        # 20 and 10 should be pending.
+        self.assertEqual(
+            2, len(record1.review_ids.filtered(lambda x: x.status == "pending"))
+        )
+        self.assertEqual(
+            0, len(record1.review_ids.filtered(lambda x: x.status == "waiting"))
+        )
+        self.assertEqual(
+            2, len(record1.review_ids.filtered(lambda x: x.status == "approved"))
+        )
+        self.assertFalse(record1.can_review)
+        # User 2 validates.
+        record2 = test_record.with_user(self.test_user_2.id)
+        self.assertTrue(record2.can_review)
+        record2.validate_tier()
+        self.assertEqual(
+            1, len(record1.review_ids.filtered(lambda x: x.status == "pending"))
+        )
+        self.assertEqual(
+            0, len(record1.review_ids.filtered(lambda x: x.status == "waiting"))
+        )
+        self.assertEqual(
+            3, len(record1.review_ids.filtered(lambda x: x.status == "approved"))
+        )
+        # User 1 validates the final tier.
+        self.assertTrue(record1.can_review)
         record1.validate_tier()
         self.assertEqual(
             0, len(record1.review_ids.filtered(lambda x: x.status == "pending"))
@@ -414,8 +471,9 @@ class TierTierValidation(CommonTierValidation):
             0, len(record1.review_ids.filtered(lambda x: x.status == "waiting"))
         )
         self.assertEqual(
-            2, len(record1.review_ids.filtered(lambda x: x.status == "approved"))
+            4, len(record1.review_ids.filtered(lambda x: x.status == "approved"))
         )
+        self.assertEqual(record1.validation_status, "validated")
 
     def test_13_onchange_review_type(self):
         tier_def_id = self.tier_def_obj.create(

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -433,10 +433,14 @@ class TierTierValidation(CommonTierValidation):
 
     def test_12_approve_sequence_same_user_bypassed(self):
         """Similar to test_12_approve_sequence, with all same users,
-        but approve_sequence_bypass is True"""
+        but approve_sequence_bypass is True
+        Sequence of reviewers: A, A, B, A.
+        When A validates, it should only validate the first two (A, A) and stop at B.
+        """
         # Create new test record
         test_record = self.test_model.create({"test_field": 2.5})
         # Create tier definitions
+        # sequence 40 (User 1)
         self.tier_def_obj.create(
             {
                 "model_id": self.tester_model.id,
@@ -445,9 +449,34 @@ class TierTierValidation(CommonTierValidation):
                 "definition_domain": "[('test_field', '>', 1.0)]",
                 "approve_sequence": True,
                 "approve_sequence_bypass": True,
+                "sequence": 40,
+            }
+        )
+        # sequence 30 (User 1)
+        self.tier_def_obj.create(
+            {
+                "model_id": self.tester_model.id,
+                "review_type": "individual",
+                "reviewer_id": self.test_user_1.id,
+                "definition_domain": "[('test_field', '>', 1.0)]",
+                "approve_sequence": True,
+                "approve_sequence_bypass": True,
+                "sequence": 30,
+            }
+        )
+        # sequence 20 (User 2)
+        self.tier_def_obj.create(
+            {
+                "model_id": self.tester_model.id,
+                "review_type": "individual",
+                "reviewer_id": self.test_user_2.id,
+                "definition_domain": "[('test_field', '>', 1.0)]",
+                "approve_sequence": True,
+                "approve_sequence_bypass": True,
                 "sequence": 20,
             }
         )
+        # sequence 10 (User 1)
         self.tier_def_obj.create(
             {
                 "model_id": self.tester_model.id,
@@ -467,13 +496,41 @@ class TierTierValidation(CommonTierValidation):
         record1 = test_record.with_user(self.test_user_1.id)
         self.assertTrue(record1.can_review)
         # When the first tier is validated, all the rest will be approved.
-        self.assertEqual(len(record1.review_ids), 2)
+        self.assertEqual(len(record1.review_ids), 4)
         self.assertEqual(
-            1, len(record1.review_ids.filtered(lambda x: x.status == "waiting"))
+            3, len(record1.review_ids.filtered(lambda x: x.status == "waiting"))
         )
         self.assertEqual(
             1, len(record1.review_ids.filtered(lambda x: x.status == "pending"))
         )
+        record1.validate_tier()
+        # After user 1 validates, they should have approved exactly 2 tiers: 40 and 30
+        # 20 and 10 should be pending.
+        self.assertEqual(
+            2, len(record1.review_ids.filtered(lambda x: x.status == "pending"))
+        )
+        self.assertEqual(
+            0, len(record1.review_ids.filtered(lambda x: x.status == "waiting"))
+        )
+        self.assertEqual(
+            2, len(record1.review_ids.filtered(lambda x: x.status == "approved"))
+        )
+        self.assertFalse(record1.can_review)
+        # User 2 validates.
+        record2 = test_record.with_user(self.test_user_2.id)
+        self.assertTrue(record2.can_review)
+        record2.validate_tier()
+        self.assertEqual(
+            1, len(record1.review_ids.filtered(lambda x: x.status == "pending"))
+        )
+        self.assertEqual(
+            0, len(record1.review_ids.filtered(lambda x: x.status == "waiting"))
+        )
+        self.assertEqual(
+            3, len(record1.review_ids.filtered(lambda x: x.status == "approved"))
+        )
+        # User 1 validates the final tier.
+        self.assertTrue(record1.can_review)
         record1.validate_tier()
         self.assertEqual(
             0, len(record1.review_ids.filtered(lambda x: x.status == "pending"))
@@ -482,8 +539,9 @@ class TierTierValidation(CommonTierValidation):
             0, len(record1.review_ids.filtered(lambda x: x.status == "waiting"))
         )
         self.assertEqual(
-            2, len(record1.review_ids.filtered(lambda x: x.status == "approved"))
+            4, len(record1.review_ids.filtered(lambda x: x.status == "approved"))
         )
+        self.assertEqual(record1.validation_status, "validated")
 
     def test_13_onchange_review_type(self):
         tier_def_id = self.tier_def_obj.create(


### PR DESCRIPTION
## Summary

Forward-port of [OCA/server-ux#1141](https://github.com/OCA/server-ux/pull/1141) (authored by @Saran440 / Ecosoft) onto 19.0.

`approve_sequence_bypass` is supposed to skip a tier's approval *only* when the previous (consecutive) tier was already validated by the same reviewer. The current logic instead bypasses whenever the same reviewer appears anywhere in the earlier tiers — even with gaps. With multi-tier workflows where the same person sits on tier 1 and tier 3 but a third party owns tier 2, that lets the workflow auto-approve tier 3 the moment tier 1 is signed, before tier 2 even gets a chance.

This forward-port restricts the bypass to the immediately previous sequence so non-consecutive overlaps no longer auto-approve.

## Credit

Original commit: `48049458` by @Saran440 / Ecosoft. Cherry-picked unchanged onto 19.0; the surrounding code was identical to 18.0 so no resolution was needed.
