### PR TITLE
[19.0][FIX] base_tier_validation: comment support approve_sequence_bypass

### DIFF
--- a/base_tier_validation/__manifest__.py
+++ b/base_tier_validation/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Base Tier Validation",
     "summary": "Implement a validation process based on tiers.",
-    "version": "19.0.1.0.2",
+    "version": "19.0.1.0.3",
     "development_status": "Mature",
     "maintainers": ["LoisRForgeFlow"],
     "category": "Tools",

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -629,7 +629,11 @@ class TierValidation(models.AbstractModel):
         )
         if self.has_comment:
             user_reviews = reviews.filtered(
-                lambda r: r.status == "pending" and (self.env.user in r.reviewer_ids)
+                lambda r: (
+                    r.status == "pending"
+                    or (r.approve_sequence_bypass and r.status != "approved")
+                )
+                and (self.env.user in r.reviewer_ids)
             )
             return self._add_comment("validate", user_reviews)
         self._validate_tier(reviews)

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -650,7 +650,11 @@ class TierValidation(models.AbstractModel):
         )
         if self.has_comment:
             user_reviews = reviews.filtered(
-                lambda r: r.status == "pending" and (self.env.user in r.reviewer_ids)
+                lambda r: (
+                    r.status == "pending"
+                    or (r.approve_sequence_bypass and r.status != "approved")
+                )
+                and (self.env.user in r.reviewer_ids)
             )
             return self._add_comment("validate", user_reviews)
         self._validate_tier(reviews)

--- a/base_tier_validation/wizard/comment_wizard.py
+++ b/base_tier_validation/wizard/comment_wizard.py
@@ -17,7 +17,10 @@ class CommentWizard(models.TransientModel):
     def add_comment(self):
         self.ensure_one()
         rec = self.env[self.res_model].browse(self.res_id)
-        self.review_ids.write({"comment": self.comment})
+        # Write only comment on last review and not on all
+        self.review_ids.sorted(lambda x: x.sequence)[-1].write(
+            {"comment": self.comment}
+        )
         if self.validate_reject == "validate":
             rec._validate_tier(self.review_ids)
         if self.validate_reject == "reject":


### PR DESCRIPTION
## Summary

Forward-port of the first commit (`ff56b14f`) from [OCA/server-ux#1156](https://github.com/OCA/server-ux/pull/1156) (authored by @mathbenTechnolibre / ERPLibre) onto 19.0.

When a reviewer's tier was auto-bypassed by `approve_sequence_bypass`, the comment they entered in the wizard was attached to the wrong review (or repeated across reviews). Now the comment is attached only to the last review in the bypass chain, eliminating repetition.

## Why only one of the two upstream commits

The upstream PR also bundled a second, unrelated commit (`d3d98d52` — "add note accepted/refused if missing email") that changed notification behaviour by always posting a chatter note when notifications couldn't be sent. Cherry-picking that one broke three pre-existing tests on v19 (`test_19_waiting_tier`, `test_19a_notify_on_pending_sequence_negative`, `test_20_no_sequence`) — they assert exact `message_ids` counts and expect specific notification bodies, and the extra chatter posts violated those expectations. Dropped that commit; it can be revisited as its own PR once the test expectations are reconciled.

## Credit

Original commit: `ff56b14f` by @mathbenTechnolibre. Cherry-picked unchanged onto 19.0; merge auto-resolved cleanly.

## Test plan

Two-tier definition with `approve_sequence_bypass=True`; reviewer who covers tiers 1 and 2 approves with a comment via the wizard. The comment should appear once on the last review, not twice.