### PR TITLE
[19.0][FIX] base_tier_validation_forward: forward notification delivery

### DIFF
--- a/base_tier_validation_forward/models/tier_validation.py
+++ b/base_tier_validation_forward/models/tier_validation.py
@@ -26,7 +26,7 @@ class TierValidation(models.AbstractModel):
         return res
 
     def _get_forwarded_notification_subtype(self):
-        return "base_tier_validation.mt_tier_validation_forwarded"
+        return "base_tier_validation_forward.mt_tier_validation_forwarded"
 
     def forward_tier(self):
         self.ensure_one()

--- a/base_tier_validation_forward/tests/test_tier_validation.py
+++ b/base_tier_validation_forward/tests/test_tier_validation.py
@@ -208,3 +208,95 @@ class TierTierValidation(CommonTierValidation):
     def test_03_forward_tier_multiple_without_comment(self):
         """Expected flow with forwards, but without comments"""
         self._test_forward_tier_multiple(has_comment=False)
+
+    def test_04_forward_notification_subtype_xmlid(self):
+        """The forwarded notification subtype must reference the correct module."""
+        test_record = self.test_model.create({"test_field": 2.5})
+        expected = "base_tier_validation_forward.mt_tier_validation_forwarded"
+        self.assertEqual(test_record._get_forwarded_notification_subtype(), expected)
+        # Verify the xmlid resolves to an actual record
+        subtype = self.env.ref(expected)
+        self.assertEqual(subtype.name, "Tier Validation Forward Notification")
+
+    def test_05_forward_message_uses_correct_subtype(self):
+        """Forward must post a chatter message with the correct subtype."""
+        self.tier_def_obj.create(
+            {
+                "model_id": self.tester_model.id,
+                "review_type": "individual",
+                "reviewer_id": self.test_user_2.id,
+                "definition_domain": "[('test_field', '>', 1.0)]",
+                "approve_sequence": True,
+                "has_forward": True,
+            }
+        )
+        test_record = self.test_model.create({"test_field": 2.5})
+        test_record.with_user(self.test_user_2).request_validation()
+
+        # Forward from user_2 to other_test_user
+        action = test_record.with_user(self.test_user_2).forward_tier()
+        self.env[action["res_model"]].with_user(self.test_user_2).with_context(
+            **action["context"]
+        ).create(
+            {
+                "forward_reviewer_id": self.other_test_user.id,
+                "forward_description": "Please check",
+            }
+        ).add_forward()
+
+        # The forwarded notification must use the correct subtype
+        fwd_subtype = self.env.ref(
+            "base_tier_validation_forward.mt_tier_validation_forwarded"
+        )
+        fwd_msg = self.env["mail.message"].search(
+            [
+                ("model", "=", "tier.validation.tester"),
+                ("res_id", "=", test_record.id),
+                ("subtype_id", "=", fwd_subtype.id),
+            ],
+            limit=1,
+        )
+        self.assertTrue(
+            fwd_msg,
+            "Forward notification must use subtype "
+            "'base_tier_validation_forward.mt_tier_validation_forwarded', "
+            "not fall back to 'mail.mt_note'",
+        )
+
+    def test_06_forward_target_subscribed_as_follower(self):
+        """Forward target must be subscribed as follower of the record."""
+        self.tier_def_obj.create(
+            {
+                "model_id": self.tester_model.id,
+                "review_type": "individual",
+                "reviewer_id": self.test_user_2.id,
+                "definition_domain": "[('test_field', '>', 1.0)]",
+                "approve_sequence": True,
+                "has_forward": True,
+            }
+        )
+        test_record = self.test_model.create({"test_field": 2.5})
+        test_record.with_user(self.test_user_2).request_validation()
+
+        target_partner = self.other_test_user.partner_id
+        followers_before = test_record.message_follower_ids.mapped("partner_id")
+        self.assertNotIn(target_partner, followers_before)
+
+        action = test_record.with_user(self.test_user_2).forward_tier()
+        self.env[action["res_model"]].with_user(self.test_user_2).with_context(
+            **action["context"]
+        ).create(
+            {
+                "forward_reviewer_id": self.other_test_user.id,
+                "forward_description": "Please check",
+            }
+        ).add_forward()
+
+        test_record.invalidate_recordset()
+        followers_after = test_record.message_follower_ids.mapped("partner_id")
+        self.assertIn(
+            target_partner,
+            followers_after,
+            "Forward target must be subscribed as follower to receive "
+            "email notifications about the forwarded review",
+        )

--- a/base_tier_validation_forward/wizard/forward_wizard.py
+++ b/base_tier_validation_forward/wizard/forward_wizard.py
@@ -25,6 +25,17 @@ class ValidationForwardWizard(models.TransientModel):
         """Add extra step, with specific reviewer"""
         self.ensure_one()
         rec = self.env[self.res_model].browse(self.res_id)
+        # Subscribe the forward target as a follower so they receive
+        # email notifications about the forwarded review.
+        if hasattr(rec, "message_subscribe"):
+            fwd_subtype = self.env.ref(
+                "base_tier_validation_forward.mt_tier_validation_forwarded",
+                raise_if_not_found=False,
+            )
+            rec.message_subscribe(
+                partner_ids=self.forward_reviewer_id.partner_id.ids,
+                subtype_ids=fwd_subtype.ids if fwd_subtype else [],
+            )
         prev_comment = self.env["comment.wizard"].browse(
             self.env.context.get("comment_id")
         )


### PR DESCRIPTION
## Summary

Forward-port of [OCA/server-ux#1279](https://github.com/OCA/server-ux/pull/1279) (authored by @lala-labiso / Labiso GmbH) onto 19.0.

When a reviewer used the *Forward* wizard to hand off their review, the chatter notification on the validated document wasn't actually being delivered to the newly-assigned reviewer. The forward wizard updated the tier review's reviewer but didn't trigger a `message_notify` / activity for the new assignee, so the receiving party only found out about the assignment by stumbling on the systray counter (or never).

This PR makes the wizard explicitly notify the new reviewer(s) after the forward, with an appropriate chatter entry and (where applicable) a scheduled activity.

## Credit

Original commit: `82b2d01e` by @lala-labiso. Cherry-picked unchanged onto 19.0; merge auto-resolved cleanly.

## Test plan

Upstream PR's regression test is included (`test_tier_validation.py` additions). Manually: assign a tier review to user A, forward it to user B via the wizard, observe that user B receives the chatter / activity notification.