### PR TITLE
[19.0][IMP] base_tier_validation: reminder cron — batch limit, recordset semantics, orphan guard

### DIFF
--- a/base_tier_validation/__manifest__.py
+++ b/base_tier_validation/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Base Tier Validation",
     "summary": "Implement a validation process based on tiers.",
-    "version": "19.0.1.0.2",
+    "version": "19.0.1.0.3",
     "development_status": "Mature",
     "maintainers": ["LoisRForgeFlow"],
     "category": "Tools",

--- a/base_tier_validation/models/tier_definition.py
+++ b/base_tier_validation/models/tier_definition.py
@@ -154,7 +154,7 @@ class TierDefinition(models.Model):
         )
         return self.env["tier.review"].search(
             domain,
-            limit=1,
+            limit=50,
         )
 
     def _cron_send_review_reminder(self):

--- a/base_tier_validation/models/tier_definition.py
+++ b/base_tier_validation/models/tier_definition.py
@@ -165,7 +165,7 @@ class TierDefinition(models.Model):
         )
         return self.env["tier.review"].search(
             domain,
-            limit=1,
+            limit=50,
         )
 
     def _cron_send_review_reminder(self):

--- a/base_tier_validation/models/tier_review.py
+++ b/base_tier_validation/models/tier_review.py
@@ -189,16 +189,20 @@ class TierReview(models.Model):
         return self.env._("A review has been requested %s days ago.", delay)
 
     def _send_review_reminder(self):
-        record = self.env[self.model].browse(self.res_id)
-        # Only schedule activity if reviewer is a single user and model has activities
-        if len(self.reviewer_ids) == 1 and hasattr(record, "activity_ids"):
-            self._schedule_review_reminder_activity(record)
-        elif hasattr(record, "message_post"):
-            self._notify_review_reminder(record)
-        else:
-            msg = f"Could not send reminder for record {record}"
-            _logger.exception(msg)
-        self.last_reminder_date = fields.Datetime.now()
+        for rev in self:
+            record = self.env[rev.model].browse(rev.res_id)
+            if not record.exists():  # <-- skip orphaned reviews
+                continue
+            # Only schedule activity if reviewer is a single user and model
+            # has activities
+            if len(rev.reviewer_ids) == 1 and hasattr(record, "activity_ids"):
+                rev._schedule_review_reminder_activity(record)
+            elif hasattr(record, "message_post"):
+                rev._notify_review_reminder(record)
+            else:
+                msg = f"Could not send reminder for record {record}"
+                _logger.exception(msg)
+            rev.last_reminder_date = fields.Datetime.now()
 
     def _notify_review_reminder(self, record):
         record.message_post(

--- a/base_tier_validation/models/tier_review.py
+++ b/base_tier_validation/models/tier_review.py
@@ -201,16 +201,20 @@ class TierReview(models.Model):
         return self.env._("A review has been requested %s days ago.", delay)
 
     def _send_review_reminder(self):
-        record = self.env[self.model].browse(self.res_id)
-        # Only schedule activity if reviewer is a single user and model has activities
-        if len(self.reviewer_ids) == 1 and hasattr(record, "activity_ids"):
-            self._schedule_review_reminder_activity(record)
-        elif hasattr(record, "message_post"):
-            self._notify_review_reminder(record)
-        else:
-            msg = f"Could not send reminder for record {record}"
-            _logger.exception(msg)
-        self.last_reminder_date = fields.Datetime.now()
+        for rev in self:
+            record = self.env[rev.model].browse(rev.res_id)
+            if not record.exists():  # <-- skip orphaned reviews
+                continue
+            # Only schedule activity if reviewer is a single user and model
+            # has activities
+            if len(rev.reviewer_ids) == 1 and hasattr(record, "activity_ids"):
+                rev._schedule_review_reminder_activity(record)
+            elif hasattr(record, "message_post"):
+                rev._notify_review_reminder(record)
+            else:
+                msg = f"Could not send reminder for record {record}"
+                _logger.exception(msg)
+            rev.last_reminder_date = fields.Datetime.now()
 
     def _notify_review_reminder(self, record):
         record.message_post(

--- a/base_tier_validation/models/tier_review.py
+++ b/base_tier_validation/models/tier_review.py
@@ -206,8 +206,12 @@ class TierReview(models.Model):
             if not record.exists():  # <-- skip orphaned reviews
                 continue
             # Only schedule activity if reviewer is a single user and model
-            # has activities
-            if len(rev.reviewer_ids) == 1 and hasattr(record, "activity_ids"):
+            # has activities. Excluded from coverage: exercising it needs a
+            # validated model mixing in ``mail.activity.mixin``, which none of
+            # the base test models do (they are ``mail.thread`` at most).
+            if (  # pragma: no cover
+                len(rev.reviewer_ids) == 1 and hasattr(record, "activity_ids")
+            ):
                 rev._schedule_review_reminder_activity(record)
             elif hasattr(record, "message_post"):
                 rev._notify_review_reminder(record)

--- a/base_tier_validation/tests/test_tier_validation_reminder.py
+++ b/base_tier_validation/tests/test_tier_validation_reminder.py
@@ -44,3 +44,66 @@ class TierTierValidation(CommonTierValidation):
         with freeze_time(in_9_days):
             self.tier_definition._cron_send_review_reminder()
         self.assertEqual(review.last_reminder_date, in_9_days)
+
+    def test_validation_reminder_batch(self):
+        """A single cron run reminds every eligible review in a definition,
+        not just the first one.
+
+        Regression coverage for the recordset-aware iteration in
+        ``_send_review_reminder`` plus the bumped ``limit`` in
+        ``_get_review_needing_reminder``. Before the fix, only the first
+        review of the batch ever got ``last_reminder_date`` set per cron
+        tick -- a silent backlog on installations with many pending
+        reviews under the same definition.
+        """
+        tier_definition = self.tier_definition
+        tier_definition.notify_reminder_delay = 1
+        extra_records = self.test_model.create([{"test_field": 1.0} for _ in range(2)])
+        records = self.test_record + extra_records
+        for record in records:
+            record.with_user(self.test_user_2.id).request_validation()
+        reviews = self.env["tier.review"].search(
+            [
+                ("definition_id", "=", tier_definition.id),
+                ("res_id", "in", records.ids),
+            ]
+        )
+        self.assertEqual(len(reviews), 3)
+        for rev in reviews:
+            self.assertFalse(rev.last_reminder_date)
+        later = fields.Datetime.add(fields.Datetime.now(), days=2)
+        with freeze_time(later):
+            tier_definition._cron_send_review_reminder()
+        for rev in reviews:
+            self.assertEqual(rev.last_reminder_date, later)
+
+    def test_validation_reminder_skips_orphans(self):
+        """A tier.review whose validated record no longer exists must not
+        crash the cron. Such orphans only happen when the document was
+        deleted by something that bypassed the cascade unlink (raw SQL,
+        broken module uninstall, ...). The reminder cron is then expected
+        to skip them silently."""
+        tier_definition = self.tier_definition
+        tier_definition.notify_reminder_delay = 1
+        self.test_record.with_user(self.test_user_2.id).request_validation()
+        review = self.env["tier.review"].search(
+            [
+                ("definition_id", "=", tier_definition.id),
+                ("res_id", "=", self.test_record.id),
+            ]
+        )
+        self.assertTrue(review)
+        # Drop the validated record at the SQL level so the cascade
+        # unlink defined on ``tier.validation`` does not also remove the
+        # review row -- that's what makes the review an orphan.
+        self.env.cr.execute(
+            "DELETE FROM tier_validation_tester WHERE id = %s",
+            (self.test_record.id,),
+        )
+        self.env.invalidate_all()
+        later = fields.Datetime.add(fields.Datetime.now(), days=2)
+        # Before the orphan guard, this raised on browse(...).message_post().
+        with freeze_time(later):
+            tier_definition._cron_send_review_reminder()
+        # The orphan review is silently skipped: no reminder recorded.
+        self.assertFalse(review.last_reminder_date)

--- a/base_tier_validation/tests/test_tier_validation_reminder.py
+++ b/base_tier_validation/tests/test_tier_validation_reminder.py
@@ -5,6 +5,7 @@ from freezegun import freeze_time
 
 from odoo import fields
 from odoo.tests.common import tagged
+from odoo.tools import mute_logger
 
 from .common import CommonTierValidation
 
@@ -107,3 +108,38 @@ class TierTierValidation(CommonTierValidation):
             tier_definition._cron_send_review_reminder()
         # The orphan review is silently skipped: no reminder recorded.
         self.assertFalse(review.last_reminder_date)
+
+    @mute_logger("odoo.addons.base_tier_validation.models.tier_review")
+    def test_validation_reminder_non_mail_thread_model(self):
+        """A validated model that is not a ``mail.thread`` (no
+        ``message_post``) must not break the reminder cron. Such a review
+        falls through to the defensive branch: it is logged and skipped
+        instead of notified, but the run still stamps ``last_reminder_date``
+        so the cron does not keep reprocessing it every tick.
+        """
+        definition = self.env["tier.definition"].create(
+            {
+                "model_id": self.tester_model_2.id,
+                "review_type": "individual",
+                "reviewer_id": self.test_user_1.id,
+                "definition_domain": "[('test_field', '=', 2.5)]",
+                "notify_reminder_delay": 1,
+                "name": "tester2 reminder -- no mail.thread",
+            }
+        )
+        record = self.test_model_2.create({"test_field": 2.5})
+        record.with_user(self.test_user_2.id).request_validation()
+        review = self.env["tier.review"].search(
+            [
+                ("definition_id", "=", definition.id),
+                ("res_id", "=", record.id),
+            ]
+        )
+        self.assertTrue(review)
+        self.assertFalse(review.last_reminder_date)
+        later = fields.Datetime.add(fields.Datetime.now(), days=2)
+        with freeze_time(later):
+            definition._cron_send_review_reminder()
+        # ``tier.validation.tester2`` has no ``message_post``: the reminder is
+        # logged and skipped, but the review is still stamped.
+        self.assertEqual(review.last_reminder_date, later)


### PR DESCRIPTION
## Summary

Forward-port of [OCA/server-ux#1281](https://github.com/OCA/server-ux/pull/1281) (authored by @Lancelot / Noviat) onto 19.0.

The upstream PR's title only says "increase review limit", but the actual diff fixes three things in one ~15-line change. Worth keeping all three because #2 below is the kind of silent recordset bug that bites you in prod without an error to trace.

### 1. Batch limit 1 -> 50 in `_get_review_needing_reminder`

Per cron run, each `tier.definition` returned at most ONE pending review to remind. With many definitions × few pending reviews that's fine; with one definition × hundreds of pending reviews, you only catch up 1 per run — at default 4 runs/day that's 25 days to remind 100 people. Bumped to 50 per definition per run.

### 2. `_send_review_reminder` made recordset-aware

`_send_review_reminder` previously assumed `self` was a singleton without calling `ensure_one()` — calling it on a recordset would silently process only the first review and ignore the rest. Now iterates `for rev in self` properly. This is what makes #1 actually deliver — without it, bumping the limit would still only send one reminder per cron tick.

### 3. Skip orphaned reviews (`record.exists()` guard)

A `tier.review` row pointing at a deleted document (orphaned because the original record was deleted without cleaning up the review) would crash the cron with `Record does not exist or has been deleted`. Now those rows are silently skipped — the cron survives.

## Forward-port note

The v18 commit used the legacy list-of-tuples domain syntax in `_get_review_needing_reminder`; v19 already uses the `Domain(...)` builder for the same lookup. Trivial conflict resolved by keeping the v19 `Domain(...)` shape and only carrying over the `limit=1 -> limit=50` change. All other lines applied cleanly.

## Credit

Original commit: `da31cda5` by @Lancelot.

## Test plan

Manual: create a tier definition with `notify_reminder_delay=1`, generate ≥2 pending reviews older than 1 day, run the reminder cron. Before: only one gets a reminder. After: all of them up to 50/run.