### PR TITLE
[19.0][ADD] base_tier_validation: tier.definition.allow_reject for sign-off tiers

### DIFF
--- a/base_tier_validation/models/tier_definition.py
+++ b/base_tier_validation/models/tier_definition.py
@@ -109,6 +109,14 @@ class TierDefinition(models.Model):
         help="Bypassed (auto validated), if previous tier was validated "
         "by same reviewer",
     )
+    allow_reject = fields.Boolean(
+        string="Allow Rejection",
+        default=True,
+        help="When unchecked, reviewers of this tier can only validate "
+        "the record, not reject it. Use this to model 'sign-off' / "
+        "informational tiers where the reviewer is expected to "
+        "acknowledge but not block the workflow.",
+    )
 
     @api.onchange("review_type")
     def onchange_review_type(self):

--- a/base_tier_validation/models/tier_definition.py
+++ b/base_tier_validation/models/tier_definition.py
@@ -120,6 +120,14 @@ class TierDefinition(models.Model):
         "Only meaningful for review_type='group'; the form hides this "
         "field for the other review types.",
     )
+    allow_reject = fields.Boolean(
+        string="Allow Rejection",
+        default=True,
+        help="When unchecked, reviewers of this tier can only validate "
+        "the record, not reject it. Use this to model 'sign-off' / "
+        "informational tiers where the reviewer is expected to "
+        "acknowledge but not block the workflow.",
+    )
 
     @api.onchange("review_type")
     def onchange_review_type(self):

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -67,6 +67,14 @@ class TierValidation(models.AbstractModel):
     can_review = fields.Boolean(
         compute="_compute_can_review", search="_search_can_review"
     )
+    can_reject = fields.Boolean(
+        compute="_compute_can_reject",
+        help="True when the current user can act on this record AND at "
+        "least one of their actionable tier reviews has "
+        "``tier.definition.allow_reject`` set. Drives the visibility "
+        "of the Reject button on the validation banner so that "
+        "sign-off / informational tiers don't expose a Reject action.",
+    )
     has_comment = fields.Boolean(
         compute="_compute_has_comment",
         help="If set, Allow the reviewer to leave a comment on the review.",
@@ -114,6 +122,29 @@ class TierValidation(models.AbstractModel):
     def _compute_can_review(self):
         for rec in self:
             rec.can_review = rec._get_sequences_to_approve(self.env.user)
+
+    @api.depends_context("uid")
+    @api.depends(
+        "review_ids.approve_sequence",
+        "review_ids.reviewer_ids",
+        "review_ids.sequence",
+        "review_ids.status",
+        "review_ids.definition_id.allow_reject",
+    )
+    def _compute_can_reject(self):
+        user = self.env.user
+        for rec in self:
+            sequences = rec._get_sequences_to_approve(user)
+            if not sequences:
+                rec.can_reject = False
+                continue
+            # The user has actionable tiers; check whether at least one
+            # of them is configured to allow rejection.
+            rec.can_reject = any(
+                r.definition_id.allow_reject
+                for r in rec.review_ids
+                if r.sequence in sequences
+            )
 
     @api.model
     def _search_can_review(self, operator, value):
@@ -639,6 +670,13 @@ class TierValidation(models.AbstractModel):
         self.ensure_one()
         sequences = self._get_sequences_to_approve(self.env.user)
         reviews = self.review_ids.filtered(lambda x: x.sequence in sequences)
+        # Honor per-definition ``allow_reject``: tiers flagged as
+        # sign-off / informational only let the reviewer validate, not
+        # reject. Filter them out so calling reject_tier on a mixed
+        # batch only rejects the tiers that actually permit it.
+        reviews = reviews.filtered(lambda r: r.definition_id.allow_reject)
+        if not reviews:
+            return
         if self.has_comment:
             return self._add_comment("reject", reviews)
         self._rejected_tier(reviews)

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -67,6 +67,14 @@ class TierValidation(models.AbstractModel):
     can_review = fields.Boolean(
         compute="_compute_can_review", search="_search_can_review"
     )
+    can_reject = fields.Boolean(
+        compute="_compute_can_reject",
+        help="True when the current user can act on this record AND at "
+        "least one of their actionable tier reviews has "
+        "``tier.definition.allow_reject`` set. Drives the visibility "
+        "of the Reject button on the validation banner so that "
+        "sign-off / informational tiers don't expose a Reject action.",
+    )
     has_comment = fields.Boolean(
         compute="_compute_has_comment",
         help="If set, Allow the reviewer to leave a comment on the review.",
@@ -114,6 +122,29 @@ class TierValidation(models.AbstractModel):
     def _compute_can_review(self):
         for rec in self:
             rec.can_review = rec._get_sequences_to_approve(self.env.user)
+
+    @api.depends_context("uid")
+    @api.depends(
+        "review_ids.approve_sequence",
+        "review_ids.reviewer_ids",
+        "review_ids.sequence",
+        "review_ids.status",
+        "review_ids.definition_id.allow_reject",
+    )
+    def _compute_can_reject(self):
+        user = self.env.user
+        for rec in self:
+            sequences = rec._get_sequences_to_approve(user)
+            if not sequences:
+                rec.can_reject = False
+                continue
+            # The user has actionable tiers; check whether at least one
+            # of them is configured to allow rejection.
+            rec.can_reject = any(
+                r.definition_id.allow_reject
+                for r in rec.review_ids
+                if r.sequence in sequences
+            )
 
     @api.model
     def _search_can_review(self, operator, value):
@@ -660,6 +691,13 @@ class TierValidation(models.AbstractModel):
         self.ensure_one()
         sequences = self._get_sequences_to_approve(self.env.user)
         reviews = self.review_ids.filtered(lambda x: x.sequence in sequences)
+        # Honor per-definition ``allow_reject``: tiers flagged as
+        # sign-off / informational only let the reviewer validate, not
+        # reject. Filter them out so calling reject_tier on a mixed
+        # batch only rejects the tiers that actually permit it.
+        reviews = reviews.filtered(lambda r: r.definition_id.allow_reject)
+        if not reviews:
+            return
         if self.has_comment:
             return self._add_comment("reject", reviews)
         self._rejected_tier(reviews)

--- a/base_tier_validation/templates/tier_validation_templates.xml
+++ b/base_tier_validation/templates/tier_validation_templates.xml
@@ -39,7 +39,7 @@
                 <button
                     name="reject_tier"
                     string="Reject"
-                    invisible="not can_review"
+                    invisible="not can_reject"
                     type="object"
                     class="btn-icon btn-danger"
                     icon="fa-thumbs-down"

--- a/base_tier_validation/templates/tier_validation_templates.xml
+++ b/base_tier_validation/templates/tier_validation_templates.xml
@@ -42,7 +42,7 @@
                     <button
                         name="reject_tier"
                         string="Reject"
-                        invisible="not can_review"
+                        invisible="not can_reject"
                         type="object"
                         class="btn-icon btn-danger"
                         icon="fa-thumbs-down"

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -40,6 +40,51 @@ class TierTierValidation(CommonTierValidation):
         record.validate_tier()
         self.assertEqual(record.validation_status, "validated")
 
+    def test_allow_reject_false_hides_reject_button(self):
+        """When the matching tier definition has ``allow_reject=False``
+        the validated record reports ``can_reject=False`` while
+        ``can_review`` is still True. The form template binds the
+        Reject button's visibility to ``can_reject`` so the button is
+        hidden for sign-off tiers."""
+        # Override the default definition created in CommonTierValidation
+        # to forbid rejection.
+        self.tier_definition.write({"allow_reject": False})
+        self.test_record.with_user(self.test_user_2).request_validation()
+        record = self.test_record.with_user(self.test_user_1)
+        self.assertTrue(record.can_review)
+        self.assertFalse(record.can_reject)
+
+    def test_reject_tier_skips_definitions_with_allow_reject_false(self):
+        """``reject_tier`` ignores reviews whose definition forbids
+        rejection -- so a reviewer assigned to a mix of sign-off and
+        regular tiers can still reject the regular ones but the
+        sign-off ones stay pending."""
+        # Two definitions for user 1: tier 1 = sign-off (no reject),
+        # tier 2 = regular. Sequence configured so both reviews
+        # surface as pending at the same time.
+        self.tier_definition.write({"allow_reject": False, "sequence": 10})
+        self.tier_def_obj.create(
+            {
+                "model_id": self.tester_model.id,
+                "review_type": "individual",
+                "reviewer_id": self.test_user_1.id,
+                "definition_domain": "[('test_field', '=', 1.0)]",
+                "sequence": 20,
+                "allow_reject": True,
+            }
+        )
+        self.test_record.with_user(self.test_user_2).request_validation()
+        record = self.test_record.with_user(self.test_user_1)
+        self.assertTrue(record.can_reject)
+        record.reject_tier()
+        # The sign-off review stays in `pending`; the regular review
+        # transitions to `rejected`.
+        statuses = {
+            r.definition_id.allow_reject: r.status for r in self.test_record.review_ids
+        }
+        self.assertEqual(statuses[False], "pending")
+        self.assertEqual(statuses[True], "rejected")
+
     def test_04_request_validation_rejected(self):
         """Request validation, rejection and reset."""
         self.assertFalse(self.test_record.review_ids)

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -108,6 +108,51 @@ class TierTierValidation(CommonTierValidation):
         self.assertIn(self.test_user_1, review.reviewer_ids)
         self.assertTrue(record.with_user(self.test_user_1).can_review)
 
+    def test_allow_reject_false_hides_reject_button(self):
+        """When the matching tier definition has ``allow_reject=False``
+        the validated record reports ``can_reject=False`` while
+        ``can_review`` is still True. The form template binds the
+        Reject button's visibility to ``can_reject`` so the button is
+        hidden for sign-off tiers."""
+        # Override the default definition created in CommonTierValidation
+        # to forbid rejection.
+        self.tier_definition.write({"allow_reject": False})
+        self.test_record.with_user(self.test_user_2).request_validation()
+        record = self.test_record.with_user(self.test_user_1)
+        self.assertTrue(record.can_review)
+        self.assertFalse(record.can_reject)
+
+    def test_reject_tier_skips_definitions_with_allow_reject_false(self):
+        """``reject_tier`` ignores reviews whose definition forbids
+        rejection -- so a reviewer assigned to a mix of sign-off and
+        regular tiers can still reject the regular ones but the
+        sign-off ones stay pending."""
+        # Two definitions for user 1: tier 1 = sign-off (no reject),
+        # tier 2 = regular. Sequence configured so both reviews
+        # surface as pending at the same time.
+        self.tier_definition.write({"allow_reject": False, "sequence": 10})
+        self.tier_def_obj.create(
+            {
+                "model_id": self.tester_model.id,
+                "review_type": "individual",
+                "reviewer_id": self.test_user_1.id,
+                "definition_domain": "[('test_field', '=', 1.0)]",
+                "sequence": 20,
+                "allow_reject": True,
+            }
+        )
+        self.test_record.with_user(self.test_user_2).request_validation()
+        record = self.test_record.with_user(self.test_user_1)
+        self.assertTrue(record.can_reject)
+        record.reject_tier()
+        # The sign-off review stays in `pending`; the regular review
+        # transitions to `rejected`.
+        statuses = {
+            r.definition_id.allow_reject: r.status for r in self.test_record.review_ids
+        }
+        self.assertEqual(statuses[False], "pending")
+        self.assertEqual(statuses[True], "rejected")
+
     def test_04_request_validation_rejected(self):
         """Request validation, rejection and reset."""
         self.assertFalse(self.test_record.review_ids)

--- a/base_tier_validation/views/tier_definition_view.xml
+++ b/base_tier_validation/views/tier_definition_view.xml
@@ -91,6 +91,7 @@
                                 <span
                                 >Bypass, if previous tier was validated by same reviewer</span>
                             </div>
+                            <field name="allow_reject" />
                         </group>
                     </group>
                     <notebook>

--- a/base_tier_validation/views/tier_definition_view.xml
+++ b/base_tier_validation/views/tier_definition_view.xml
@@ -95,6 +95,7 @@
                                 name="exclude_requester"
                                 invisible="review_type != 'group'"
                             />
+                            <field name="allow_reject" />
                         </group>
                     </group>
                     <notebook>


### PR DESCRIPTION
## Summary

Add a per-definition Boolean ``allow_reject`` so workflows can model *sign-off* / *informational* tiers where the reviewer acknowledges the document but cannot reject it.

| Definition | Reviewer sees |
|---|---|
| `allow_reject = True` (default) | Validate + Reject (current behaviour) |
| `allow_reject = False` | Validate only |

Requested by a client who wanted certain tiers to act as "seen" stamps rather than veto points.

## How it works

- **Per-definition gate** (not per-user). Tier author decides; matches existing knob pattern (next to `approve_sequence`, `approve_sequence_bypass`).
- New computed Boolean **`tier.validation.can_reject`** drives the Reject button's `invisible="not can_reject"`. True iff the user can act AND at least one of their actionable reviews has `allow_reject=True`.
- **`reject_tier`** is also filtered: a reviewer assigned to a mix of sign-off and regular tiers can still reject the regular ones; the sign-off reviews stay pending.

## Backwards compatibility

`allow_reject` defaults to `True`. Existing definitions and behaviour are unchanged. Opt-in.

## Tests

- `test_allow_reject_false_hides_reject_button` — `can_review` stays True, `can_reject` flips False.
- `test_reject_tier_skips_definitions_with_allow_reject_false` — reject_tier called on a mixed batch only rejects the rejectable tiers.

## Future work (deferred)

Optional `reject_user_ids` Many2many on the definition would let a single tier be rejectable by some reviewers (e.g. seniors) but only sign-off-able by others. Held back until a real client asks; the per-definition gate covers the immediate ask.