### PR TITLE
[19.0][IMP] base_tier_validation: rewrite tier_review_widget collapse with native <details>

### DIFF
--- a/base_tier_validation/static/src/components/tier_review_widget/tier_review_widget.esm.js
+++ b/base_tier_validation/static/src/components/tier_review_widget/tier_review_widget.esm.js
@@ -1,33 +1,10 @@
-import {Component, useState} from "@odoo/owl";
+import {Component} from "@odoo/owl";
 import {registry} from "@web/core/registry";
-import {useService} from "@web/core/utils/hooks";
 
 export class ReviewsTable extends Component {
-    setup() {
-        super.setup();
-        this.orm = useService("orm");
-        this.state = useState({
-            collapse: false,
-        });
-    }
-
     _getReviewData() {
         const records = this.props.record.data.review_ids.records;
         return records.map((record) => record.data);
-    }
-
-    onToggleCollapse(ev) {
-        const panelHeading = ev.currentTarget.closest(".panel-heading");
-        const collapseDiv = panelHeading.nextElementSibling.matches("div#collapse1")
-            ? panelHeading.nextElementSibling
-            : null;
-        if (!collapseDiv) return;
-        if (this.state.collapse) {
-            collapseDiv.style.display = "none";
-        } else {
-            collapseDiv.style.display = "block";
-        }
-        this.state.collapse = !this.state.collapse;
     }
 }
 

--- a/base_tier_validation/static/src/components/tier_review_widget/tier_review_widget.scss
+++ b/base_tier_validation/static/src/components/tier_review_widget/tier_review_widget.scss
@@ -3,39 +3,45 @@ ul.o_review {
     max-width: 800px;
 }
 
-.panel-group {
+.o_tier_review_widget {
     min-height: auto !important;
     margin-top: -6px !important;
     padding: 16px 16px 8px 16px !important;
 }
 
-.panel-heading {
-    background-color: initial !important;
-}
-
-.panel {
-    border: 0 !important;
-}
-
-.panel-body {
+.o_tier_review_body {
     overflow-y: hidden;
     overflow-x: auto;
 }
 
-.panel-title > a,
-.panel-title > a:active {
+/* Style the native <summary> as a section heading. The browser
+   handles open/close state itself; we only re-skin the disclosure
+   triangle to match Odoo's FontAwesome caret look. */
+.o_tier_review_details > summary {
+    cursor: pointer;
+    list-style: none;
+    font-weight: bold;
+    padding: 8px 0;
     display: block;
 }
 
-.panel-heading a:before {
-    font-family: FontAwesome;
-    content: "\f0d7";
-    float: right;
-    transition: all 0.5s;
+.o_tier_review_details > summary::-webkit-details-marker {
+    display: none;
 }
 
-.panel-heading.active a:before {
-    -webkit-transform: rotate(180deg);
-    -moz-transform: rotate(180deg);
-    transform: rotate(180deg);
+.o_tier_review_details > summary::before {
+    font-family: FontAwesome;
+    content: "\f0d7";
+    margin-right: 8px;
+    display: inline-block;
+    transition: transform 0.3s;
+}
+
+.o_tier_review_details:not([open]) > summary::before {
+    transform: rotate(-90deg);
+}
+
+.o_tier_review_widget .o_tier_review_seq {
+    width: 2rem;
+    white-space: nowrap;
 }

--- a/base_tier_validation/static/src/components/tier_review_widget/tier_review_widget.xml
+++ b/base_tier_validation/static/src/components/tier_review_widget/tier_review_widget.xml
@@ -1,114 +1,103 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates>
     <t t-name="base_tier_validation.Collapse">
-        <div class="o_form_sheet panel-group">
-            <div class="panel panel-default">
-                <div class="panel-heading">
-                    <h4 class="panel-title">
-                        <a
-                            class="o_info_btn"
-                            data-toggle="state.collapse"
-                            href="#"
-                            data-target="#collapse1"
-                            t-on-click="onToggleCollapse"
-                        >
-                            Reviews
-                        </a>
-                    </h4>
-                </div>
-                <div id="collapse1" class="panel-collapse collapse active">
-                    <div class="panel-body o_review">
-                        <table class="oe_mt32 table table-condensed">
-                            <thead>
-                                <tr>
-                                    <th
-                                        name="th_sequence"
-                                        class="text-center"
-                                    >Sequence</th>
-                                    <th
-                                        name="th_requested_by"
-                                        class="text-start"
-                                    >Requested by</th>
-                                    <th name="th_name" class="text-end">Description</th>
-                                    <th
-                                        name="th_display_status"
-                                        class="text-end"
-                                    >Status</th>
-                                    <th name="th_todo_by" class="text-end">Todo by</th>
-                                    <th name="th_done_by" class="text-end">Done by</th>
-                                    <th
-                                        name="th_reviewed_date"
-                                        class="text-end"
-                                    >Validation Date</th>
-                                    <th name="th_comment" class="text-end">Comment</th>
-                                </tr>
-                            </thead>
-                            <tbody class="sale_tbody">
+        <div class="o_form_sheet o_tier_review_widget">
+            <details class="o_tier_review_details" open="open">
+                <summary class="o_tier_review_summary">Reviews</summary>
+                <div class="o_tier_review_body o_review">
+                    <table class="mt-4 table table-sm">
+                        <thead>
+                            <tr>
+                                <th
+                                    name="th_sequence"
+                                    class="text-center o_tier_review_seq"
+                                >#</th>
+                                <th
+                                    name="th_requested_by"
+                                    class="text-start"
+                                >Requested by</th>
+                                <th name="th_name" class="text-start">Description</th>
+                                <th
+                                    name="th_display_status"
+                                    class="text-start"
+                                >Status</th>
+                                <th name="th_todo_by" class="text-start">Todo by</th>
+                                <th name="th_done_by" class="text-start">Done by</th>
+                                <th
+                                    name="th_reviewed_date"
+                                    class="text-start"
+                                >Validation Date</th>
+                                <th name="th_comment" class="text-start">Comment</th>
+                            </tr>
+                        </thead>
+                        <tbody class="sale_tbody">
+                            <t
+                                t-foreach="_getReviewData()"
+                                t-as="review"
+                                t-key="review.id"
+                            >
                                 <t
-                                    t-foreach="_getReviewData()"
-                                    t-as="review"
-                                    t-key="review.id"
-                                >
-                                    <t
-                                        t-if="review.status == 'waiting' or review.status == 'cancel'"
-                                        t-set="status_class"
-                                        t-value="'text-muted'"
-                                    />
-                                    <t
-                                        t-if="review.status == 'pending'"
-                                        t-set="status_class"
-                                        t-value=""
-                                    />
-                                    <t
-                                        t-if="review.status == 'approved'"
-                                        t-set="status_class"
-                                        t-value="'alert alert-success'"
-                                    />
-                                    <t
-                                        t-if="review.status == 'rejected'"
-                                        t-set="status_class"
-                                        t-value="'alert alert-danger'"
-                                    />
-                                    <tr t-att-class="status_class">
-                                        <td name="td_sequence" class="text-center">
-                                            <span t-out="review.sequence" />
-                                        </td>
-                                        <td name="td_requested_by" class="text-start">
+                                    t-if="review.status == 'waiting' or review.status == 'cancel'"
+                                    t-set="status_class"
+                                    t-value="'text-muted'"
+                                />
+                                <t
+                                    t-if="review.status == 'pending'"
+                                    t-set="status_class"
+                                    t-value="''"
+                                />
+                                <t
+                                    t-if="review.status == 'approved'"
+                                    t-set="status_class"
+                                    t-value="'table-success'"
+                                />
+                                <t
+                                    t-if="review.status == 'rejected'"
+                                    t-set="status_class"
+                                    t-value="'table-danger'"
+                                />
+                                <tr t-att-class="status_class">
+                                    <td
+                                        name="td_sequence"
+                                        class="text-center o_tier_review_seq"
+                                    >
+                                        <span t-out="review.sequence" />
+                                    </td>
+                                    <td name="td_requested_by" class="text-start">
+                                        <span
+                                            t-out="review.requested_by.display_name"
+                                        />
+                                    </td>
+                                    <td name="td_name" class="text-start">
+                                        <span t-out="review.name" />
+                                    </td>
+                                    <td name="td_display_status" class="text-start">
+                                        <span t-out="review.display_status" />
+                                    </td>
+                                    <td name="td_todo_by" class="text-start">
+                                        <span t-out="review.todo_by" />
+                                    </td>
+                                    <td name="td_done_by" class="text-start">
+                                        <span t-out="review.done_by.display_name" />
+                                    </td>
+                                    <td name="td_reviewed_date" class="text-start">
+                                        <t t-if="review.reviewed_formated_date">
                                             <span
-                                                t-out="review.requested_by.display_name"
+                                                t-out="review.reviewed_formated_date"
                                             />
-                                        </td>
-                                        <td name="td_name" class="text-end">
-                                            <span t-out="review.name" />
-                                        </td>
-                                        <td name="td_display_status" class="text-end">
-                                            <span t-out="review.display_status" />
-                                        </td>
-                                        <td name="td_todo_by" class="text-end">
-                                            <span t-out="review.todo_by" />
-                                        </td>
-                                        <td name="td_done_by" class="text-end">
-                                            <span t-out="review.done_by.display_name" />
-                                        </td>
-                                        <td name="td_reviewed_date" class="text-end">
-                                            <t t-if="review.reviewed_formated_date">
-                                                <span
-                                                    t-out="review.reviewed_formated_date"
-                                                />
-                                            </t>
-                                        </td>
-                                        <td name="td_comment" class="text-start">
-                                            <t t-if="review.comment">
-                                                <span t-out="review.comment" />
-                                            </t>
-                                        </td>
-                                    </tr>
-                                </t>
-                            </tbody>
-                        </table>
-                    </div>
+                                        </t>
+                                    </td>
+                                    <td name="td_comment" class="text-start">
+                                        <t t-if="review.comment">
+                                            <span t-out="review.comment" />
+                                        </t>
+                                    </td>
+                                </tr>
+                            </t>
+                        </tbody>
+                    </table>
                 </div>
-            </div>
+            </details>
         </div>
     </t>
 </templates>


### PR DESCRIPTION
## Summary

Replace the OWL-driven panel/card collapse machinery in the embedded *Reviews* widget with the native HTML5 `<details>` / `<summary>` element. Browser handles open/close state, keyboard accessibility, and the disclosure triangle; no JavaScript needed.

## What goes away

- `onToggleCollapse` handler (~13 lines walking `ev.currentTarget.closest(".panel-heading")` then toggling `style.display` manually).
- `useState` import and `this.state.collapse` boolean.
- `<a class="o_info_btn" data-toggle="..." t-on-click="...">` shim and the explicit `<div id="collapse1" class="collapse">` wrapper.
- Bootstrap 3 leftover SCSS (`.panel-group`, `.panel-heading`, `.panel-title`, `.panel-body` all dropped — none of these classes exist in Bootstrap 5 which Odoo 19 ships).

## What replaces it

- `<details class="o_tier_review_details" open="open"><summary>Reviews</summary><div class="o_tier_review_body">...</div></details>`. The `open` attribute defaults to expanded, matching the previous default.
- A small SCSS layer re-skinning the disclosure marker so it looks like Odoo's FontAwesome caret: `summary::before { content: "\f0d7" }`, rotates `-90°` when the `<details>` is closed. `summary::-webkit-details-marker { display: none }` so we don't render two triangles.

## Net effect

| | Before | After |
|---|---:|---:|
| JS | ~30 LOC | 13 LOC |
| SCSS | 12 selectors (Bootstrap 3 + custom) | 5 selectors (Odoo namespaced) |
| Accessibility | `<a href="#">` shim, click-only | Native `<details>`, Space/Enter, screen-reader-aware |

Same UX (click *Reviews* heading to toggle, defaults to open).

## Overlap with PR #23

PR #23 modernised the same widget from Bootstrap 3 (`panel-*`) to Bootstrap 5 (`card-*`). This PR goes one step further and removes the surrounding card scaffolding entirely. If PR #23 lands first, this PR will need a trivial conflict resolution on the same files — net result is identical. If this PR lands first, the Bootstrap-modernisation commit in PR #23 becomes redundant for these files (the rest of PR #23 — search view, avatars, icons, coverage tests — is unaffected).

## Test plan

- Open a validated document (e.g. `account.move` under tier validation). The *Reviews* section is open by default with the caret pointing down.
- Click the *Reviews* heading: panel collapses, caret rotates to point right.
- Click again: expands back.
- Tab-focus the summary and press Space or Enter: same toggle. (Keyboard accessibility was not available with the previous `<a>` shim.)