### PR TITLE
[ADD] base_tier_validation: dedicated manager group, menu out of Technical

### DIFF
--- a/base_tier_validation/README.rst
+++ b/base_tier_validation/README.rst
@@ -64,9 +64,16 @@ Configuration
 
 To configure this module, you need to:
 
-1. Go to *Settings > Technical > Tier Validations > Tier Definition*.
+1. Go to *Tier Validations > Tier Definition* (top-level menu, no
+   Settings / Technical access required).
 2. Create as many tiers as you want for any model having tier validation
    functionality.
+
+The *Tier Validations* menu is gated by the **Tier Validation
+Administrator** group. Assign it to trusted key users (Settings > Users
+> *Tier Validation* category) so they can manage definitions and
+exceptions **without** granting them Settings / Technical access. System
+administrators receive this group automatically.
 
 **Note:**
 
@@ -124,6 +131,18 @@ improvement will be very valuable.
 
 Changelog
 =========
+
+19.0.2.0.0 (2026-05-17)
+-----------------------
+
+Features:
+
+- New **Tier Validation Administrator** security group. Trusted key
+  users can now manage tier definitions and exceptions without being
+  granted Settings / Technical access. System administrators receive the
+  group automatically (back-compat).
+- The *Tier Validations* menu has moved out of *Settings > Technical* to
+  a top-level menu, gated by the new group.
 
 19.0.1.0.4 (2026-05-13)
 -----------------------

--- a/base_tier_validation/__manifest__.py
+++ b/base_tier_validation/__manifest__.py
@@ -15,6 +15,7 @@
     "depends": ["mail"],
     "data": [
         # Security
+        "security/tier_validation_groups.xml",
         "security/ir.model.access.csv",
         "security/tier_validation_security.xml",
         # Data

--- a/base_tier_validation/readme/CONFIGURE.md
+++ b/base_tier_validation/readme/CONFIGURE.md
@@ -1,9 +1,15 @@
 To configure this module, you need to:
 
-1.  Go to *Settings \> Technical \> Tier Validations \> Tier
-    Definition*.
+1.  Go to *Tier Validations \> Tier Definition* (top-level menu, no
+    Settings / Technical access required).
 2.  Create as many tiers as you want for any model having tier
     validation functionality.
+
+The *Tier Validations* menu is gated by the **Tier Validation
+Administrator** group. Assign it to trusted key users (Settings \>
+Users \> *Tier Validation* category) so they can manage definitions and
+exceptions **without** granting them Settings / Technical access.
+System administrators receive this group automatically.
 
 **Note:**
 

--- a/base_tier_validation/readme/HISTORY.md
+++ b/base_tier_validation/readme/HISTORY.md
@@ -1,3 +1,14 @@
+## 19.0.2.0.0 (2026-05-17)
+
+Features:
+
+- New **Tier Validation Administrator** security group. Trusted key
+  users can now manage tier definitions and exceptions without being
+  granted Settings / Technical access. System administrators receive
+  the group automatically (back-compat).
+- The *Tier Validations* menu has moved out of *Settings > Technical*
+  to a top-level menu, gated by the new group.
+
 ## 19.0.1.0.1 (2026-05-12)
 
 Fixes:

--- a/base_tier_validation/readme/HISTORY.md
+++ b/base_tier_validation/readme/HISTORY.md
@@ -1,3 +1,14 @@
+## 19.0.2.0.0 (2026-05-17)
+
+Features:
+
+- New **Tier Validation Administrator** security group. Trusted key
+  users can now manage tier definitions and exceptions without being
+  granted Settings / Technical access. System administrators receive
+  the group automatically (back-compat).
+- The *Tier Validations* menu has moved out of *Settings > Technical*
+  to a top-level menu, gated by the new group.
+
 ## 19.0.1.0.4 (2026-05-13)
 
 UI improvement:

--- a/base_tier_validation/security/ir.model.access.csv
+++ b/base_tier_validation/security/ir.model.access.csv
@@ -9,3 +9,6 @@ access_tier_definition_settings,tier.definition.settings,model_tier_definition,b
 access_comment_wizard,access.comment.wizard,model_comment_wizard,base.group_user,1,1,1,1
 access_tier_validation_exceptions_all,tier.validation.exceptions,model_tier_validation_exception,base.group_user,1,0,0,0
 access_tier_validation_exceptions_settings,tier.validation.exceptions,model_tier_validation_exception,base.group_system,1,1,1,1
+access_tier_definition_manager,tier.definition.manager,model_tier_definition,base_tier_validation.group_tier_validation_manager,1,1,1,1
+access_tier_validation_exceptions_manager,tier.validation.exceptions.manager,model_tier_validation_exception,base_tier_validation.group_tier_validation_manager,1,1,1,1
+access_tier_review_manager,tier.review.manager,model_tier_review,base_tier_validation.group_tier_validation_manager,1,1,1,1

--- a/base_tier_validation/security/tier_validation_groups.xml
+++ b/base_tier_validation/security/tier_validation_groups.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 ForgeFlow S.L. (https://www.forgeflow.com)
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo noupdate="0">
+    <record id="module_category_tier_validation" model="ir.module.category">
+        <field name="name">Tier Validation</field>
+        <field name="sequence">20</field>
+    </record>
+    <record id="privilege_tier_validation" model="res.groups.privilege">
+        <field name="name">Tier Validation</field>
+        <field name="category_id" ref="module_category_tier_validation" />
+    </record>
+    <record id="group_tier_validation_manager" model="res.groups">
+        <field name="name">Administrator</field>
+        <field name="privilege_id" ref="privilege_tier_validation" />
+    </record>
+    <!-- Back-compat: system administrators keep full access and still see
+         the (now top-level) Tier Validations menu. -->
+    <record id="base.group_system" model="res.groups">
+        <field
+            name="implied_ids"
+            eval="[(4, ref('base_tier_validation.group_tier_validation_manager'))]"
+        />
+    </record>
+</odoo>

--- a/base_tier_validation/static/description/index.html
+++ b/base_tier_validation/static/description/index.html
@@ -398,31 +398,32 @@ compute method in <tt class="docutils literal">_get_after_validation_exceptions<
 <li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
 <li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-2">Known issues / Roadmap</a></li>
 <li><a class="reference internal" href="#changelog" id="toc-entry-3">Changelog</a><ul>
-<li><a class="reference internal" href="#section-1" id="toc-entry-4">19.0.1.0.4 (2026-05-13)</a></li>
-<li><a class="reference internal" href="#section-2" id="toc-entry-5">19.0.1.0.1 (2026-05-12)</a></li>
-<li><a class="reference internal" href="#section-3" id="toc-entry-6">17.0.1.0.0 (2024-01-10)</a></li>
-<li><a class="reference internal" href="#section-4" id="toc-entry-7">14.0.1.0.0 (2020-11-19)</a></li>
-<li><a class="reference internal" href="#section-5" id="toc-entry-8">13.0.1.2.2 (2020-08-30)</a></li>
-<li><a class="reference internal" href="#section-6" id="toc-entry-9">12.0.3.3.1 (2019-12-02)</a></li>
-<li><a class="reference internal" href="#section-7" id="toc-entry-10">12.0.3.3.0 (2019-11-27)</a></li>
-<li><a class="reference internal" href="#section-8" id="toc-entry-11">12.0.3.2.1 (2019-11-26)</a></li>
-<li><a class="reference internal" href="#section-9" id="toc-entry-12">12.0.3.2.0 (2019-11-25)</a></li>
-<li><a class="reference internal" href="#section-10" id="toc-entry-13">12.0.3.1.0 (2019-07-08)</a></li>
-<li><a class="reference internal" href="#section-11" id="toc-entry-14">12.0.3.0.0 (2019-12-02)</a></li>
-<li><a class="reference internal" href="#section-12" id="toc-entry-15">12.0.2.1.0 (2019-05-29)</a></li>
-<li><a class="reference internal" href="#section-13" id="toc-entry-16">12.0.2.0.0 (2019-05-28)</a></li>
-<li><a class="reference internal" href="#section-14" id="toc-entry-17">12.0.1.0.0 (2019-02-18)</a></li>
-<li><a class="reference internal" href="#section-15" id="toc-entry-18">11.0.1.0.0 (2018-05-09)</a></li>
-<li><a class="reference internal" href="#section-16" id="toc-entry-19">10.0.1.0.0 (2018-03-26)</a></li>
-<li><a class="reference internal" href="#section-17" id="toc-entry-20">9.0.1.0.0 (2017-12-02)</a></li>
+<li><a class="reference internal" href="#section-1" id="toc-entry-4">19.0.2.0.0 (2026-05-17)</a></li>
+<li><a class="reference internal" href="#section-2" id="toc-entry-5">19.0.1.0.4 (2026-05-13)</a></li>
+<li><a class="reference internal" href="#section-3" id="toc-entry-6">19.0.1.0.1 (2026-05-12)</a></li>
+<li><a class="reference internal" href="#section-4" id="toc-entry-7">17.0.1.0.0 (2024-01-10)</a></li>
+<li><a class="reference internal" href="#section-5" id="toc-entry-8">14.0.1.0.0 (2020-11-19)</a></li>
+<li><a class="reference internal" href="#section-6" id="toc-entry-9">13.0.1.2.2 (2020-08-30)</a></li>
+<li><a class="reference internal" href="#section-7" id="toc-entry-10">12.0.3.3.1 (2019-12-02)</a></li>
+<li><a class="reference internal" href="#section-8" id="toc-entry-11">12.0.3.3.0 (2019-11-27)</a></li>
+<li><a class="reference internal" href="#section-9" id="toc-entry-12">12.0.3.2.1 (2019-11-26)</a></li>
+<li><a class="reference internal" href="#section-10" id="toc-entry-13">12.0.3.2.0 (2019-11-25)</a></li>
+<li><a class="reference internal" href="#section-11" id="toc-entry-14">12.0.3.1.0 (2019-07-08)</a></li>
+<li><a class="reference internal" href="#section-12" id="toc-entry-15">12.0.3.0.0 (2019-12-02)</a></li>
+<li><a class="reference internal" href="#section-13" id="toc-entry-16">12.0.2.1.0 (2019-05-29)</a></li>
+<li><a class="reference internal" href="#section-14" id="toc-entry-17">12.0.2.0.0 (2019-05-28)</a></li>
+<li><a class="reference internal" href="#section-15" id="toc-entry-18">12.0.1.0.0 (2019-02-18)</a></li>
+<li><a class="reference internal" href="#section-16" id="toc-entry-19">11.0.1.0.0 (2018-05-09)</a></li>
+<li><a class="reference internal" href="#section-17" id="toc-entry-20">10.0.1.0.0 (2018-03-26)</a></li>
+<li><a class="reference internal" href="#section-18" id="toc-entry-21">9.0.1.0.0 (2017-12-02)</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-21">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-22">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-23">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-24">Contributors</a></li>
-<li><a class="reference internal" href="#other-credits" id="toc-entry-25">Other credits</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-26">Maintainers</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-22">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-23">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-24">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-25">Contributors</a></li>
+<li><a class="reference internal" href="#other-credits" id="toc-entry-26">Other credits</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-27">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -431,10 +432,16 @@ compute method in <tt class="docutils literal">_get_after_validation_exceptions<
 <h2><a class="toc-backref" href="#toc-entry-1">Configuration</a></h2>
 <p>To configure this module, you need to:</p>
 <ol class="arabic simple">
-<li>Go to <em>Settings &gt; Technical &gt; Tier Validations &gt; Tier Definition</em>.</li>
+<li>Go to <em>Tier Validations &gt; Tier Definition</em> (top-level menu, no
+Settings / Technical access required).</li>
 <li>Create as many tiers as you want for any model having tier validation
 functionality.</li>
 </ol>
+<p>The <em>Tier Validations</em> menu is gated by the <strong>Tier Validation
+Administrator</strong> group. Assign it to trusted key users (Settings &gt; Users
+&gt; <em>Tier Validation</em> category) so they can manage definitions and
+exceptions <strong>without</strong> granting them Settings / Technical access. System
+administrators receive this group automatically.</p>
 <p><strong>Note:</strong></p>
 <ul class="simple">
 <li>If check <em>Notify Reviewers on Creation</em>, all possible reviewers will
@@ -491,7 +498,19 @@ recurring updates that can change the expected behavior.</p>
 <div class="section" id="changelog">
 <h2><a class="toc-backref" href="#toc-entry-3">Changelog</a></h2>
 <div class="section" id="section-1">
-<h3><a class="toc-backref" href="#toc-entry-4">19.0.1.0.4 (2026-05-13)</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-4">19.0.2.0.0 (2026-05-17)</a></h3>
+<p>Features:</p>
+<ul class="simple">
+<li>New <strong>Tier Validation Administrator</strong> security group. Trusted key
+users can now manage tier definitions and exceptions without being
+granted Settings / Technical access. System administrators receive the
+group automatically (back-compat).</li>
+<li>The <em>Tier Validations</em> menu has moved out of <em>Settings &gt; Technical</em> to
+a top-level menu, gated by the new group.</li>
+</ul>
+</div>
+<div class="section" id="section-2">
+<h3><a class="toc-backref" href="#toc-entry-5">19.0.1.0.4 (2026-05-13)</a></h3>
 <p>UI improvement:</p>
 <ul class="simple">
 <li>The “needs to be validated” banner shown above tier-validated
@@ -507,8 +526,8 @@ banner template now reads from the long-standing
 the model but never rendered.</li>
 </ul>
 </div>
-<div class="section" id="section-2">
-<h3><a class="toc-backref" href="#toc-entry-5">19.0.1.0.1 (2026-05-12)</a></h3>
+<div class="section" id="section-3">
+<h3><a class="toc-backref" href="#toc-entry-6">19.0.1.0.1 (2026-05-12)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Restore auto-promotion of the lowest-sequence review to <tt class="docutils literal">pending</tt>
@@ -530,18 +549,18 @@ only to default subtypes; <tt class="docutils literal">message_post</tt> with th
 <tt class="docutils literal">subtype_ids</tt> explicitly (mirroring <tt class="docutils literal">_notify_review_requested</tt>).</li>
 </ul>
 </div>
-<div class="section" id="section-3">
-<h3><a class="toc-backref" href="#toc-entry-6">17.0.1.0.0 (2024-01-10)</a></h3>
+<div class="section" id="section-4">
+<h3><a class="toc-backref" href="#toc-entry-7">17.0.1.0.0 (2024-01-10)</a></h3>
 <p>Migrated to Odoo 17. Merged module with tier_validation_waiting. To
 support sending messages in a validation sequence when it is their turn
 to validate.</p>
 </div>
-<div class="section" id="section-4">
-<h3><a class="toc-backref" href="#toc-entry-7">14.0.1.0.0 (2020-11-19)</a></h3>
+<div class="section" id="section-5">
+<h3><a class="toc-backref" href="#toc-entry-8">14.0.1.0.0 (2020-11-19)</a></h3>
 <p>Migrated to Odoo 14.</p>
 </div>
-<div class="section" id="section-5">
-<h3><a class="toc-backref" href="#toc-entry-8">13.0.1.2.2 (2020-08-30)</a></h3>
+<div class="section" id="section-6">
+<h3><a class="toc-backref" href="#toc-entry-9">13.0.1.2.2 (2020-08-30)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>When using approve_sequence option in any tier.definition there can be
@@ -550,84 +569,84 @@ inconsistencies in the systray notifications</li>
 sequence, but also other sequence for the same approver</li>
 </ul>
 </div>
-<div class="section" id="section-6">
-<h3><a class="toc-backref" href="#toc-entry-9">12.0.3.3.1 (2019-12-02)</a></h3>
+<div class="section" id="section-7">
+<h3><a class="toc-backref" href="#toc-entry-10">12.0.3.3.1 (2019-12-02)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Show comment on Reviews Table.</li>
 <li>Edit notification with approve_sequence.</li>
 </ul>
 </div>
-<div class="section" id="section-7">
-<h3><a class="toc-backref" href="#toc-entry-10">12.0.3.3.0 (2019-11-27)</a></h3>
+<div class="section" id="section-8">
+<h3><a class="toc-backref" href="#toc-entry-11">12.0.3.3.0 (2019-11-27)</a></h3>
 <p>New features:</p>
 <ul class="simple">
 <li>Add comment on Reviews Table.</li>
 <li>Approve by sequence.</li>
 </ul>
 </div>
-<div class="section" id="section-8">
-<h3><a class="toc-backref" href="#toc-entry-11">12.0.3.2.1 (2019-11-26)</a></h3>
+<div class="section" id="section-9">
+<h3><a class="toc-backref" href="#toc-entry-12">12.0.3.2.1 (2019-11-26)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Remove message_subscribe_users</li>
 </ul>
 </div>
-<div class="section" id="section-9">
-<h3><a class="toc-backref" href="#toc-entry-12">12.0.3.2.0 (2019-11-25)</a></h3>
+<div class="section" id="section-10">
+<h3><a class="toc-backref" href="#toc-entry-13">12.0.3.2.0 (2019-11-25)</a></h3>
 <p>New features:</p>
 <ul class="simple">
 <li>Notify reviewers</li>
 </ul>
 </div>
-<div class="section" id="section-10">
-<h3><a class="toc-backref" href="#toc-entry-13">12.0.3.1.0 (2019-07-08)</a></h3>
+<div class="section" id="section-11">
+<h3><a class="toc-backref" href="#toc-entry-14">12.0.3.1.0 (2019-07-08)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Singleton error</li>
 </ul>
 </div>
-<div class="section" id="section-11">
-<h3><a class="toc-backref" href="#toc-entry-14">12.0.3.0.0 (2019-12-02)</a></h3>
+<div class="section" id="section-12">
+<h3><a class="toc-backref" href="#toc-entry-15">12.0.3.0.0 (2019-12-02)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Edit Reviews Table</li>
 </ul>
 </div>
-<div class="section" id="section-12">
-<h3><a class="toc-backref" href="#toc-entry-15">12.0.2.1.0 (2019-05-29)</a></h3>
+<div class="section" id="section-13">
+<h3><a class="toc-backref" href="#toc-entry-16">12.0.2.1.0 (2019-05-29)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Edit drop-down style width and position</li>
 </ul>
 </div>
-<div class="section" id="section-13">
-<h3><a class="toc-backref" href="#toc-entry-16">12.0.2.0.0 (2019-05-28)</a></h3>
+<div class="section" id="section-14">
+<h3><a class="toc-backref" href="#toc-entry-17">12.0.2.0.0 (2019-05-28)</a></h3>
 <p>New features:</p>
 <ul class="simple">
 <li>Pass parameters as functions.</li>
 <li>Add Systray.</li>
 </ul>
 </div>
-<div class="section" id="section-14">
-<h3><a class="toc-backref" href="#toc-entry-17">12.0.1.0.0 (2019-02-18)</a></h3>
+<div class="section" id="section-15">
+<h3><a class="toc-backref" href="#toc-entry-18">12.0.1.0.0 (2019-02-18)</a></h3>
 <p>Migrated to Odoo 12.</p>
 </div>
-<div class="section" id="section-15">
-<h3><a class="toc-backref" href="#toc-entry-18">11.0.1.0.0 (2018-05-09)</a></h3>
+<div class="section" id="section-16">
+<h3><a class="toc-backref" href="#toc-entry-19">11.0.1.0.0 (2018-05-09)</a></h3>
 <p>Migrated to Odoo 11.</p>
 </div>
-<div class="section" id="section-16">
-<h3><a class="toc-backref" href="#toc-entry-19">10.0.1.0.0 (2018-03-26)</a></h3>
+<div class="section" id="section-17">
+<h3><a class="toc-backref" href="#toc-entry-20">10.0.1.0.0 (2018-03-26)</a></h3>
 <p>Migrated to Odoo 10.</p>
 </div>
-<div class="section" id="section-17">
-<h3><a class="toc-backref" href="#toc-entry-20">9.0.1.0.0 (2017-12-02)</a></h3>
+<div class="section" id="section-18">
+<h3><a class="toc-backref" href="#toc-entry-21">9.0.1.0.0 (2017-12-02)</a></h3>
 <p>First version.</p>
 </div>
 </div>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#toc-entry-21">Bug Tracker</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-22">Bug Tracker</a></h2>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/tier-validation/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -635,15 +654,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#toc-entry-22">Credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-23">Credits</a></h2>
 <div class="section" id="authors">
-<h3><a class="toc-backref" href="#toc-entry-23">Authors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-24">Authors</a></h3>
 <ul class="simple">
 <li>ForgeFlow</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h3><a class="toc-backref" href="#toc-entry-24">Contributors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-25">Contributors</a></h3>
 <ul class="simple">
 <li>Lois Rilo &lt;<a class="reference external" href="mailto:lois.rilo&#64;forgeflow.com">lois.rilo&#64;forgeflow.com</a>&gt;</li>
 <li>Naglis Jonaitis &lt;<a class="reference external" href="mailto:naglis&#64;versada.eu">naglis&#64;versada.eu</a>&gt;</li>
@@ -668,10 +687,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="other-credits">
-<h3><a class="toc-backref" href="#toc-entry-25">Other credits</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-26">Other credits</a></h3>
 </div>
 <div class="section" id="maintainers">
-<h3><a class="toc-backref" href="#toc-entry-26">Maintainers</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-27">Maintainers</a></h3>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -7,9 +7,9 @@ from unittest import mock
 from lxml import etree
 
 from odoo import Command
-from odoo.exceptions import ValidationError
+from odoo.exceptions import AccessError, ValidationError
 from odoo.fields import Domain
-from odoo.tests import Form
+from odoo.tests import Form, new_test_user
 from odoo.tests.common import tagged
 
 from ..models.tier_validation import BASE_EXCEPTION_FIELDS as BEF
@@ -1453,6 +1453,38 @@ class TierTierValidation(CommonTierValidation):
 
         # Review_ids should not be copied when duplicating a user
         self.assertFalse(new_user.review_ids.ids)
+
+    def test_35_manager_group_can_configure_without_technical(self):
+        """A trusted key user holding only the Tier Validation
+        Administrator group (no system / erp_manager / Technical) can
+        manage tier definitions; a plain internal user cannot; and the
+        system admin implies the manager group for back-compat."""
+        manager = new_test_user(
+            self.env,
+            name="Tier Manager",
+            login="tier_manager",
+            groups="base.group_user,base_tier_validation.group_tier_validation_manager",
+        )
+        plain = new_test_user(
+            self.env, name="Plain", login="plain_user", groups="base.group_user"
+        )
+        vals = {
+            "model_id": self.tester_model.id,
+            "review_type": "individual",
+            "reviewer_id": self.test_user_1.id,
+            "definition_domain": "[('test_field', '=', 1.0)]",
+        }
+        definition = self.env["tier.definition"].with_user(manager).create(dict(vals))
+        self.assertTrue(definition.id)
+        definition.with_user(manager).write({"sequence": 99})
+        with self.assertRaises(AccessError):
+            self.env["tier.definition"].with_user(plain).create(dict(vals))
+        # Back-compat: system administrators implicitly get the new group.
+        self.assertTrue(
+            self.test_user_1.has_group(
+                "base_tier_validation.group_tier_validation_manager"
+            )
+        )
 
 
 @tagged("at_install")

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -9,7 +9,7 @@ from lxml import etree
 from odoo import Command
 from odoo.exceptions import AccessError, ValidationError
 from odoo.fields import Domain
-from odoo.tests import Form
+from odoo.tests import Form, new_test_user
 from odoo.tests.common import tagged
 
 from ..models.tier_validation import BASE_EXCEPTION_FIELDS as BEF
@@ -1598,6 +1598,38 @@ class TierTierValidation(CommonTierValidation):
 
         # Review_ids should not be copied when duplicating a user
         self.assertFalse(new_user.review_ids.ids)
+
+    def test_35_manager_group_can_configure_without_technical(self):
+        """A trusted key user holding only the Tier Validation
+        Administrator group (no system / erp_manager / Technical) can
+        manage tier definitions; a plain internal user cannot; and the
+        system admin implies the manager group for back-compat."""
+        manager = new_test_user(
+            self.env,
+            name="Tier Manager",
+            login="tier_manager",
+            groups="base.group_user,base_tier_validation.group_tier_validation_manager",
+        )
+        plain = new_test_user(
+            self.env, name="Plain", login="plain_user", groups="base.group_user"
+        )
+        vals = {
+            "model_id": self.tester_model.id,
+            "review_type": "individual",
+            "reviewer_id": self.test_user_1.id,
+            "definition_domain": "[('test_field', '=', 1.0)]",
+        }
+        definition = self.env["tier.definition"].with_user(manager).create(dict(vals))
+        self.assertTrue(definition.id)
+        definition.with_user(manager).write({"sequence": 99})
+        with self.assertRaises(AccessError):
+            self.env["tier.definition"].with_user(plain).create(dict(vals))
+        # Back-compat: system administrators implicitly get the new group.
+        self.assertTrue(
+            self.test_user_1.has_group(
+                "base_tier_validation.group_tier_validation_manager"
+            )
+        )
 
 
 @tagged("at_install")

--- a/base_tier_validation/views/tier_definition_view.xml
+++ b/base_tier_validation/views/tier_definition_view.xml
@@ -160,7 +160,9 @@
     <menuitem
         id="menu_tier_confirmation"
         name="Tier Validations"
-        parent="base.menu_custom"
+        groups="base_tier_validation.group_tier_validation_manager"
+        web_icon="base_tier_validation,static/description/icon.png"
+        sequence="80"
     />
     <menuitem
         id="menu_tier_definition"

--- a/base_tier_validation/views/tier_definition_view.xml
+++ b/base_tier_validation/views/tier_definition_view.xml
@@ -164,7 +164,9 @@
     <menuitem
         id="menu_tier_confirmation"
         name="Tier Validations"
-        parent="base.menu_custom"
+        groups="base_tier_validation.group_tier_validation_manager"
+        web_icon="base_tier_validation,static/description/icon.png"
+        sequence="80"
     />
     <menuitem
         id="menu_tier_definition"


### PR DESCRIPTION
## Problem

Managing tier definitions today requires giving a user access to
*Settings > Technical*: the *Tier Validations* menu is nested under
`base.menu_custom`, `tier.definition` write is gated to
`base.group_erp_manager`, and `tier.validation.exception` write to
`base.group_system`. There is **no dedicated tier-validation group**.

For deployments where a trusted client key user should maintain tier
definitions, the only option is granting erp-manager / Technical
access -- which lets them damage the whole system. We need a
least-privilege path.

## Change

- New security group **Tier Validation Administrator**
  (`group_tier_validation_manager`) under a new *Tier Validation*
  module category, so it is a clean selectable role in
  *Settings > Users*.
- `ir.model.access` rows granting that group CRUD on `tier.definition`,
  `tier.validation.exception` and `tier.review`.
- The *Tier Validations* menu is relocated **out of Settings >
  Technical** to a top-level menu, gated by the new group.
- Back-compat: `base.group_system` implies the new group, so existing
  administrators keep full access and still see the (now top-level)
  menu. Existing `erp_manager` / `group_user` access rows are left
  untouched.
- Manifest load order: the new `security/tier_validation_groups.xml`
  loads before `ir.model.access.csv` (which references the new group).

## Open question for reviewers

An `erp_manager` who is **not** also a `system` admin keeps
`tier.definition` write via the existing `access_tier_definition_settings`
row, but loses *automatic menu visibility* once the menu leaves
Technical. Left as-is per the requested design (only `group_system`
implies the new group). Happy to also add
`base.group_erp_manager` -> implied if reviewers prefer.

## Tests

`test_35_manager_group_can_configure_without_technical`:
- a user with only `group_user` + `group_tier_validation_manager`
  (no system / erp_manager / Technical) can create and write a
  `tier.definition`;
- a plain `group_user` user gets `AccessError`;
- a `group_system` user implies the manager group (back-compat).

## Scope

19.0 only for now. The 18.0 backport (OCA/server-ux, identical menu /
security structure) is deferred to a separate follow-up.