### PR TITLE
[IMP] base_tier_validation: clearer, self-checking tier definitions

### DIFF
--- a/base_tier_validation/README.rst
+++ b/base_tier_validation/README.rst
@@ -125,6 +125,27 @@ improvement will be very valuable.
 Changelog
 =========
 
+19.0.2.0.0 (2026-05-19)
+-----------------------
+
+Improvements:
+
+- Tier definitions now show a plain-language **Summary** (on the form
+  and in the list) describing in one sentence which documents the rule
+  applies to and who must validate.
+- Added inline help to the model, filter, reviewer-field, sequence and
+  approval fields, with a concrete domain example.
+- The Tier Definition list now opens grouped by document type, in
+  sequence order, so the full ordered tier chain per model is visible at
+  a glance. In multi-company databases definitions are ordered by
+  company first (and the Company column is shown by default) so each
+  company's tiers stay together instead of being interleaved.
+- A malformed filter (domain) is now reported with a clear error when
+  the definition is saved, instead of only failing later when validation
+  is requested. The reviewer (user, group or field) is now required in
+  the form once a "Validated by" type is chosen, and the form warns when
+  a rule has no filter.
+
 19.0.1.0.4 (2026-05-13)
 -----------------------
 

--- a/base_tier_validation/models/tier_definition.py
+++ b/base_tier_validation/models/tier_definition.py
@@ -1,13 +1,17 @@
 # Copyright 2017 ForgeFlow S.L. (https://www.forgeflow.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from ast import literal_eval
+
 from odoo import api, fields, models
+from odoo.exceptions import ValidationError
 from odoo.fields import Domain
 
 
 class TierDefinition(models.Model):
     _name = "tier.definition"
     _description = "Tier Definition"
+    _order = "company_id, sequence, id"
 
     @api.model
     def _get_default_name(self):
@@ -24,10 +28,18 @@ class TierDefinition(models.Model):
         default=lambda self: self._get_default_name(),
         translate=True,
     )
+    tier_summary = fields.Char(
+        string="Summary",
+        compute="_compute_tier_summary",
+        help="Plain-language description of when this rule applies and who "
+        "must validate.",
+    )
     model_id = fields.Many2one(
         comodel_name="ir.model",
         string="Referenced Model",
         domain=lambda self: [("model", "in", self._get_tier_validation_model_names())],
+        help="The document type this validation rule applies to. Only models "
+        "that opted in to tier validation are listed.",
     )
     model = fields.Char(related="model_id.model", index=True, store=True)
     review_type = fields.Selection(
@@ -38,6 +50,11 @@ class TierDefinition(models.Model):
             ("group", "Any user in a specific group"),
             ("field", "Field in related record"),
         ],
+        help="Who is allowed to validate this tier:\n"
+        "- Specific user: a named user.\n"
+        "- Any user in a specific group: any member of the chosen group.\n"
+        "- Field in related record: the user/group stored in a field of the "
+        "document itself (e.g. its salesperson or manager).",
     )
     allow_write_for_reviewer = fields.Boolean(
         string="Allow Write For Reviewers",
@@ -51,6 +68,9 @@ class TierDefinition(models.Model):
         comodel_name="ir.model.fields",
         string="Reviewer field",
         domain="[('id', 'in', valid_reviewer_field_ids)]",
+        help="A field of the document that points to the reviewer(s): a "
+        "user field or a group field (e.g. the document's salesperson or "
+        "approving manager).",
     )
     valid_reviewer_field_ids = fields.One2many(
         comodel_name="ir.model.fields",
@@ -59,9 +79,18 @@ class TierDefinition(models.Model):
     definition_type = fields.Selection(
         string="Definition", selection=[("domain", "Domain")], default="domain"
     )
-    definition_domain = fields.Char()
+    definition_domain = fields.Char(
+        help="Filter deciding which records of the model this rule applies "
+        "to. Leave empty to apply to every record. Example: "
+        "[('amount_total', '>', 1000)] -- only documents whose total "
+        "exceeds 1000.",
+    )
     active = fields.Boolean(default=True)
-    sequence = fields.Integer(default=30)
+    sequence = fields.Integer(
+        default=30,
+        help="Order of this tier. Lower numbers are validated first when "
+        "'Approve by sequence' is enabled.",
+    )
     company_id = fields.Many2one(
         comodel_name="res.company",
         string="Company",
@@ -103,7 +132,9 @@ class TierDefinition(models.Model):
     approve_sequence = fields.Boolean(
         string="Approve by sequence",
         default=False,
-        help="Approval order by the specified sequence number",
+        help="If set, this tier can only be validated once all tiers with a "
+        "lower sequence number have been validated (strict order). If not "
+        "set, this tier can be validated at any time.",
     )
     approve_sequence_bypass = fields.Boolean(
         help="Bypassed (auto validated), if previous tier was validated "
@@ -134,6 +165,114 @@ class TierDefinition(models.Model):
             rec.valid_reviewer_field_ids = valid_reviewer_fields.get(
                 rec.model, IrModelFields
             )
+
+    def _describe_domain(self):
+        """Best-effort plain-language rendering of ``definition_domain``.
+
+        Never raises: falls back to the raw string when the domain cannot be
+        parsed or contains operators we do not spell out.
+        """
+        self.ensure_one()
+        raw = (self.definition_domain or "").strip()
+        if not raw or raw == "[]":
+            return self.env._("for all records")
+        try:
+            parsed = literal_eval(raw)
+        except (ValueError, SyntaxError):
+            return self.env._("where %s", raw)
+        if not isinstance(parsed, list | tuple) or not parsed:
+            return self.env._("for all records")
+        model = self.env[self.model] if self.model and self.model in self.env else None
+        leaves = []
+        for item in parsed:
+            if isinstance(item, list | tuple) and len(item) == 3:
+                fname, operator, value = item
+                label = fname
+                if model is not None and fname in model._fields:
+                    label = model._fields[fname].string or fname
+                leaves.append(f"{label} {operator} {value!r}")
+        if not leaves:
+            return self.env._("where %s", raw)
+        return self.env._("where %s", " and ".join(leaves))
+
+    def _describe_reviewer(self):
+        self.ensure_one()
+        by_type = {
+            "individual": self.reviewer_id.display_name,
+            "group": self.reviewer_group_id.display_name,
+            "field": self.reviewer_field_id.field_description
+            or self.reviewer_field_id.name,
+        }
+        return by_type.get(self.review_type) or ""
+
+    @api.depends(
+        "model_id",
+        "model",
+        "sequence",
+        "approve_sequence",
+        "review_type",
+        "reviewer_id",
+        "reviewer_group_id",
+        "reviewer_field_id",
+        "definition_domain",
+    )
+    def _compute_tier_summary(self):
+        rt_labels = dict(self.fields_get(["review_type"])["review_type"]["selection"])
+        for rec in self:
+            if not rec.model_id:
+                rec.tier_summary = ""
+                continue
+            target = rec._describe_reviewer()
+            rec.tier_summary = self.env._(
+                "Tier %(seq)s — %(model)s %(cond)s: validated by %(how)s"
+                "%(target)s%(ordered)s",
+                seq=rec.sequence,
+                model=rec.model_id.name or rec.model,
+                cond=rec._describe_domain(),
+                how=rt_labels.get(rec.review_type, rec.review_type or ""),
+                target=(" " + target) if target else "",
+                ordered=self.env._(" (in sequence)") if rec.approve_sequence else "",
+            )
+
+    @api.constrains("definition_domain")
+    def _check_definition_domain(self):
+        for rec in self:
+            raw = (rec.definition_domain or "").strip()
+            if not raw:
+                continue
+            try:
+                parsed = literal_eval(raw)
+            except (ValueError, SyntaxError) as err:
+                raise ValidationError(
+                    self.env._(
+                        "The filter of tier definition '%(name)s' is not "
+                        "valid: %(err)s",
+                        name=rec.name,
+                        err=err,
+                    )
+                ) from err
+            if not isinstance(parsed, list | tuple):
+                raise ValidationError(
+                    self.env._(
+                        "The filter of tier definition '%(name)s' must be a "
+                        "list of conditions, e.g. "
+                        "[('amount_total', '>', 1000)].",
+                        name=rec.name,
+                    )
+                )
+
+    @api.onchange("definition_domain")
+    def _onchange_definition_domain_warn_empty(self):
+        if not (self.definition_domain or "").strip() and self.model_id:
+            return {
+                "warning": {
+                    "title": self.env._("Heads up"),
+                    "message": self.env._(
+                        "This rule has no filter, so it will apply to every %s.",
+                        self.model_id.name or self.model,
+                    ),
+                }
+            }
 
     def _get_review_needing_reminder(self):
         """Return all the reviews that have the reminder setup."""

--- a/base_tier_validation/models/tier_definition.py
+++ b/base_tier_validation/models/tier_definition.py
@@ -1,13 +1,17 @@
 # Copyright 2017 ForgeFlow S.L. (https://www.forgeflow.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from ast import literal_eval
+
 from odoo import api, fields, models
+from odoo.exceptions import ValidationError
 from odoo.fields import Domain
 
 
 class TierDefinition(models.Model):
     _name = "tier.definition"
     _description = "Tier Definition"
+    _order = "company_id, sequence, id"
 
     @api.model
     def _get_default_name(self):
@@ -24,10 +28,18 @@ class TierDefinition(models.Model):
         default=lambda self: self._get_default_name(),
         translate=True,
     )
+    tier_summary = fields.Char(
+        string="Summary",
+        compute="_compute_tier_summary",
+        help="Plain-language description of when this rule applies and who "
+        "must validate.",
+    )
     model_id = fields.Many2one(
         comodel_name="ir.model",
         string="Referenced Model",
         domain=lambda self: [("model", "in", self._get_tier_validation_model_names())],
+        help="The document type this validation rule applies to. Only models "
+        "that opted in to tier validation are listed.",
     )
     model = fields.Char(related="model_id.model", index=True, store=True)
     review_type = fields.Selection(
@@ -38,6 +50,11 @@ class TierDefinition(models.Model):
             ("group", "Any user in a specific group"),
             ("field", "Field in related record"),
         ],
+        help="Who is allowed to validate this tier:\n"
+        "- Specific user: a named user.\n"
+        "- Any user in a specific group: any member of the chosen group.\n"
+        "- Field in related record: the user/group stored in a field of the "
+        "document itself (e.g. its salesperson or manager).",
     )
     allow_write_for_reviewer = fields.Boolean(
         string="Allow Write For Reviewers",
@@ -51,6 +68,9 @@ class TierDefinition(models.Model):
         comodel_name="ir.model.fields",
         string="Reviewer field",
         domain="[('id', 'in', valid_reviewer_field_ids)]",
+        help="A field of the document that points to the reviewer(s): a "
+        "user field or a group field (e.g. the document's salesperson or "
+        "approving manager).",
     )
     valid_reviewer_field_ids = fields.One2many(
         comodel_name="ir.model.fields",
@@ -59,9 +79,18 @@ class TierDefinition(models.Model):
     definition_type = fields.Selection(
         string="Definition", selection=[("domain", "Domain")], default="domain"
     )
-    definition_domain = fields.Char()
+    definition_domain = fields.Char(
+        help="Filter deciding which records of the model this rule applies "
+        "to. Leave empty to apply to every record. Example: "
+        "[('amount_total', '>', 1000)] -- only documents whose total "
+        "exceeds 1000.",
+    )
     active = fields.Boolean(default=True)
-    sequence = fields.Integer(default=30)
+    sequence = fields.Integer(
+        default=30,
+        help="Order of this tier. Lower numbers are validated first when "
+        "'Approve by sequence' is enabled.",
+    )
     company_id = fields.Many2one(
         comodel_name="res.company",
         string="Company",
@@ -103,7 +132,9 @@ class TierDefinition(models.Model):
     approve_sequence = fields.Boolean(
         string="Approve by sequence",
         default=False,
-        help="Approval order by the specified sequence number",
+        help="If set, this tier can only be validated once all tiers with a "
+        "lower sequence number have been validated (strict order). If not "
+        "set, this tier can be validated at any time.",
     )
     approve_sequence_bypass = fields.Boolean(
         help="Bypassed (auto validated), if previous tier was validated "
@@ -145,6 +176,114 @@ class TierDefinition(models.Model):
             rec.valid_reviewer_field_ids = valid_reviewer_fields.get(
                 rec.model, IrModelFields
             )
+
+    def _describe_domain(self):
+        """Best-effort plain-language rendering of ``definition_domain``.
+
+        Never raises: falls back to the raw string when the domain cannot be
+        parsed or contains operators we do not spell out.
+        """
+        self.ensure_one()
+        raw = (self.definition_domain or "").strip()
+        if not raw or raw == "[]":
+            return self.env._("for all records")
+        try:
+            parsed = literal_eval(raw)
+        except (ValueError, SyntaxError):
+            return self.env._("where %s", raw)
+        if not isinstance(parsed, list | tuple) or not parsed:
+            return self.env._("for all records")
+        model = self.env[self.model] if self.model and self.model in self.env else None
+        leaves = []
+        for item in parsed:
+            if isinstance(item, list | tuple) and len(item) == 3:
+                fname, operator, value = item
+                label = fname
+                if model is not None and fname in model._fields:
+                    label = model._fields[fname].string or fname
+                leaves.append(f"{label} {operator} {value!r}")
+        if not leaves:
+            return self.env._("where %s", raw)
+        return self.env._("where %s", " and ".join(leaves))
+
+    def _describe_reviewer(self):
+        self.ensure_one()
+        by_type = {
+            "individual": self.reviewer_id.display_name,
+            "group": self.reviewer_group_id.display_name,
+            "field": self.reviewer_field_id.field_description
+            or self.reviewer_field_id.name,
+        }
+        return by_type.get(self.review_type) or ""
+
+    @api.depends(
+        "model_id",
+        "model",
+        "sequence",
+        "approve_sequence",
+        "review_type",
+        "reviewer_id",
+        "reviewer_group_id",
+        "reviewer_field_id",
+        "definition_domain",
+    )
+    def _compute_tier_summary(self):
+        rt_labels = dict(self.fields_get(["review_type"])["review_type"]["selection"])
+        for rec in self:
+            if not rec.model_id:
+                rec.tier_summary = ""
+                continue
+            target = rec._describe_reviewer()
+            rec.tier_summary = self.env._(
+                "Tier %(seq)s — %(model)s %(cond)s: validated by %(how)s"
+                "%(target)s%(ordered)s",
+                seq=rec.sequence,
+                model=rec.model_id.name or rec.model,
+                cond=rec._describe_domain(),
+                how=rt_labels.get(rec.review_type, rec.review_type or ""),
+                target=(" " + target) if target else "",
+                ordered=self.env._(" (in sequence)") if rec.approve_sequence else "",
+            )
+
+    @api.constrains("definition_domain")
+    def _check_definition_domain(self):
+        for rec in self:
+            raw = (rec.definition_domain or "").strip()
+            if not raw:
+                continue
+            try:
+                parsed = literal_eval(raw)
+            except (ValueError, SyntaxError) as err:
+                raise ValidationError(
+                    self.env._(
+                        "The filter of tier definition '%(name)s' is not "
+                        "valid: %(err)s",
+                        name=rec.name,
+                        err=err,
+                    )
+                ) from err
+            if not isinstance(parsed, list | tuple):
+                raise ValidationError(
+                    self.env._(
+                        "The filter of tier definition '%(name)s' must be a "
+                        "list of conditions, e.g. "
+                        "[('amount_total', '>', 1000)].",
+                        name=rec.name,
+                    )
+                )
+
+    @api.onchange("definition_domain")
+    def _onchange_definition_domain_warn_empty(self):
+        if not (self.definition_domain or "").strip() and self.model_id:
+            return {
+                "warning": {
+                    "title": self.env._("Heads up"),
+                    "message": self.env._(
+                        "This rule has no filter, so it will apply to every %s.",
+                        self.model_id.name or self.model,
+                    ),
+                }
+            }
 
     def _get_review_needing_reminder(self):
         """Return all the reviews that have the reminder setup."""

--- a/base_tier_validation/readme/HISTORY.md
+++ b/base_tier_validation/readme/HISTORY.md
@@ -1,3 +1,23 @@
+## 19.0.2.0.0 (2026-05-19)
+
+Improvements:
+
+- Tier definitions now show a plain-language **Summary** (on the form
+  and in the list) describing in one sentence which documents the rule
+  applies to and who must validate.
+- Added inline help to the model, filter, reviewer-field, sequence and
+  approval fields, with a concrete domain example.
+- The Tier Definition list now opens grouped by document type, in
+  sequence order, so the full ordered tier chain per model is visible
+  at a glance. In multi-company databases definitions are ordered by
+  company first (and the Company column is shown by default) so each
+  company's tiers stay together instead of being interleaved.
+- A malformed filter (domain) is now reported with a clear error when
+  the definition is saved, instead of only failing later when
+  validation is requested. The reviewer (user, group or field) is now
+  required in the form once a "Validated by" type is chosen, and the
+  form warns when a rule has no filter.
+
 ## 19.0.1.0.1 (2026-05-12)
 
 Fixes:

--- a/base_tier_validation/readme/HISTORY.md
+++ b/base_tier_validation/readme/HISTORY.md
@@ -1,3 +1,23 @@
+## 19.0.2.0.0 (2026-05-19)
+
+Improvements:
+
+- Tier definitions now show a plain-language **Summary** (on the form
+  and in the list) describing in one sentence which documents the rule
+  applies to and who must validate.
+- Added inline help to the model, filter, reviewer-field, sequence and
+  approval fields, with a concrete domain example.
+- The Tier Definition list now opens grouped by document type, in
+  sequence order, so the full ordered tier chain per model is visible
+  at a glance. In multi-company databases definitions are ordered by
+  company first (and the Company column is shown by default) so each
+  company's tiers stay together instead of being interleaved.
+- A malformed filter (domain) is now reported with a clear error when
+  the definition is saved, instead of only failing later when
+  validation is requested. The reviewer (user, group or field) is now
+  required in the form once a "Validated by" type is chosen, and the
+  form warns when a rule has no filter.
+
 ## 19.0.1.0.4 (2026-05-13)
 
 UI improvement:

--- a/base_tier_validation/static/description/index.html
+++ b/base_tier_validation/static/description/index.html
@@ -398,31 +398,32 @@ compute method in <tt class="docutils literal">_get_after_validation_exceptions<
 <li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
 <li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-2">Known issues / Roadmap</a></li>
 <li><a class="reference internal" href="#changelog" id="toc-entry-3">Changelog</a><ul>
-<li><a class="reference internal" href="#section-1" id="toc-entry-4">19.0.1.0.4 (2026-05-13)</a></li>
-<li><a class="reference internal" href="#section-2" id="toc-entry-5">19.0.1.0.1 (2026-05-12)</a></li>
-<li><a class="reference internal" href="#section-3" id="toc-entry-6">17.0.1.0.0 (2024-01-10)</a></li>
-<li><a class="reference internal" href="#section-4" id="toc-entry-7">14.0.1.0.0 (2020-11-19)</a></li>
-<li><a class="reference internal" href="#section-5" id="toc-entry-8">13.0.1.2.2 (2020-08-30)</a></li>
-<li><a class="reference internal" href="#section-6" id="toc-entry-9">12.0.3.3.1 (2019-12-02)</a></li>
-<li><a class="reference internal" href="#section-7" id="toc-entry-10">12.0.3.3.0 (2019-11-27)</a></li>
-<li><a class="reference internal" href="#section-8" id="toc-entry-11">12.0.3.2.1 (2019-11-26)</a></li>
-<li><a class="reference internal" href="#section-9" id="toc-entry-12">12.0.3.2.0 (2019-11-25)</a></li>
-<li><a class="reference internal" href="#section-10" id="toc-entry-13">12.0.3.1.0 (2019-07-08)</a></li>
-<li><a class="reference internal" href="#section-11" id="toc-entry-14">12.0.3.0.0 (2019-12-02)</a></li>
-<li><a class="reference internal" href="#section-12" id="toc-entry-15">12.0.2.1.0 (2019-05-29)</a></li>
-<li><a class="reference internal" href="#section-13" id="toc-entry-16">12.0.2.0.0 (2019-05-28)</a></li>
-<li><a class="reference internal" href="#section-14" id="toc-entry-17">12.0.1.0.0 (2019-02-18)</a></li>
-<li><a class="reference internal" href="#section-15" id="toc-entry-18">11.0.1.0.0 (2018-05-09)</a></li>
-<li><a class="reference internal" href="#section-16" id="toc-entry-19">10.0.1.0.0 (2018-03-26)</a></li>
-<li><a class="reference internal" href="#section-17" id="toc-entry-20">9.0.1.0.0 (2017-12-02)</a></li>
+<li><a class="reference internal" href="#section-1" id="toc-entry-4">19.0.2.0.0 (2026-05-19)</a></li>
+<li><a class="reference internal" href="#section-2" id="toc-entry-5">19.0.1.0.4 (2026-05-13)</a></li>
+<li><a class="reference internal" href="#section-3" id="toc-entry-6">19.0.1.0.1 (2026-05-12)</a></li>
+<li><a class="reference internal" href="#section-4" id="toc-entry-7">17.0.1.0.0 (2024-01-10)</a></li>
+<li><a class="reference internal" href="#section-5" id="toc-entry-8">14.0.1.0.0 (2020-11-19)</a></li>
+<li><a class="reference internal" href="#section-6" id="toc-entry-9">13.0.1.2.2 (2020-08-30)</a></li>
+<li><a class="reference internal" href="#section-7" id="toc-entry-10">12.0.3.3.1 (2019-12-02)</a></li>
+<li><a class="reference internal" href="#section-8" id="toc-entry-11">12.0.3.3.0 (2019-11-27)</a></li>
+<li><a class="reference internal" href="#section-9" id="toc-entry-12">12.0.3.2.1 (2019-11-26)</a></li>
+<li><a class="reference internal" href="#section-10" id="toc-entry-13">12.0.3.2.0 (2019-11-25)</a></li>
+<li><a class="reference internal" href="#section-11" id="toc-entry-14">12.0.3.1.0 (2019-07-08)</a></li>
+<li><a class="reference internal" href="#section-12" id="toc-entry-15">12.0.3.0.0 (2019-12-02)</a></li>
+<li><a class="reference internal" href="#section-13" id="toc-entry-16">12.0.2.1.0 (2019-05-29)</a></li>
+<li><a class="reference internal" href="#section-14" id="toc-entry-17">12.0.2.0.0 (2019-05-28)</a></li>
+<li><a class="reference internal" href="#section-15" id="toc-entry-18">12.0.1.0.0 (2019-02-18)</a></li>
+<li><a class="reference internal" href="#section-16" id="toc-entry-19">11.0.1.0.0 (2018-05-09)</a></li>
+<li><a class="reference internal" href="#section-17" id="toc-entry-20">10.0.1.0.0 (2018-03-26)</a></li>
+<li><a class="reference internal" href="#section-18" id="toc-entry-21">9.0.1.0.0 (2017-12-02)</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-21">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-22">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-23">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-24">Contributors</a></li>
-<li><a class="reference internal" href="#other-credits" id="toc-entry-25">Other credits</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-26">Maintainers</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-22">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-23">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-24">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-25">Contributors</a></li>
+<li><a class="reference internal" href="#other-credits" id="toc-entry-26">Other credits</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-27">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -491,7 +492,28 @@ recurring updates that can change the expected behavior.</p>
 <div class="section" id="changelog">
 <h2><a class="toc-backref" href="#toc-entry-3">Changelog</a></h2>
 <div class="section" id="section-1">
-<h3><a class="toc-backref" href="#toc-entry-4">19.0.1.0.4 (2026-05-13)</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-4">19.0.2.0.0 (2026-05-19)</a></h3>
+<p>Improvements:</p>
+<ul class="simple">
+<li>Tier definitions now show a plain-language <strong>Summary</strong> (on the form
+and in the list) describing in one sentence which documents the rule
+applies to and who must validate.</li>
+<li>Added inline help to the model, filter, reviewer-field, sequence and
+approval fields, with a concrete domain example.</li>
+<li>The Tier Definition list now opens grouped by document type, in
+sequence order, so the full ordered tier chain per model is visible at
+a glance. In multi-company databases definitions are ordered by
+company first (and the Company column is shown by default) so each
+company’s tiers stay together instead of being interleaved.</li>
+<li>A malformed filter (domain) is now reported with a clear error when
+the definition is saved, instead of only failing later when validation
+is requested. The reviewer (user, group or field) is now required in
+the form once a “Validated by” type is chosen, and the form warns when
+a rule has no filter.</li>
+</ul>
+</div>
+<div class="section" id="section-2">
+<h3><a class="toc-backref" href="#toc-entry-5">19.0.1.0.4 (2026-05-13)</a></h3>
 <p>UI improvement:</p>
 <ul class="simple">
 <li>The “needs to be validated” banner shown above tier-validated
@@ -507,8 +529,8 @@ banner template now reads from the long-standing
 the model but never rendered.</li>
 </ul>
 </div>
-<div class="section" id="section-2">
-<h3><a class="toc-backref" href="#toc-entry-5">19.0.1.0.1 (2026-05-12)</a></h3>
+<div class="section" id="section-3">
+<h3><a class="toc-backref" href="#toc-entry-6">19.0.1.0.1 (2026-05-12)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Restore auto-promotion of the lowest-sequence review to <tt class="docutils literal">pending</tt>
@@ -530,18 +552,18 @@ only to default subtypes; <tt class="docutils literal">message_post</tt> with th
 <tt class="docutils literal">subtype_ids</tt> explicitly (mirroring <tt class="docutils literal">_notify_review_requested</tt>).</li>
 </ul>
 </div>
-<div class="section" id="section-3">
-<h3><a class="toc-backref" href="#toc-entry-6">17.0.1.0.0 (2024-01-10)</a></h3>
+<div class="section" id="section-4">
+<h3><a class="toc-backref" href="#toc-entry-7">17.0.1.0.0 (2024-01-10)</a></h3>
 <p>Migrated to Odoo 17. Merged module with tier_validation_waiting. To
 support sending messages in a validation sequence when it is their turn
 to validate.</p>
 </div>
-<div class="section" id="section-4">
-<h3><a class="toc-backref" href="#toc-entry-7">14.0.1.0.0 (2020-11-19)</a></h3>
+<div class="section" id="section-5">
+<h3><a class="toc-backref" href="#toc-entry-8">14.0.1.0.0 (2020-11-19)</a></h3>
 <p>Migrated to Odoo 14.</p>
 </div>
-<div class="section" id="section-5">
-<h3><a class="toc-backref" href="#toc-entry-8">13.0.1.2.2 (2020-08-30)</a></h3>
+<div class="section" id="section-6">
+<h3><a class="toc-backref" href="#toc-entry-9">13.0.1.2.2 (2020-08-30)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>When using approve_sequence option in any tier.definition there can be
@@ -550,84 +572,84 @@ inconsistencies in the systray notifications</li>
 sequence, but also other sequence for the same approver</li>
 </ul>
 </div>
-<div class="section" id="section-6">
-<h3><a class="toc-backref" href="#toc-entry-9">12.0.3.3.1 (2019-12-02)</a></h3>
+<div class="section" id="section-7">
+<h3><a class="toc-backref" href="#toc-entry-10">12.0.3.3.1 (2019-12-02)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Show comment on Reviews Table.</li>
 <li>Edit notification with approve_sequence.</li>
 </ul>
 </div>
-<div class="section" id="section-7">
-<h3><a class="toc-backref" href="#toc-entry-10">12.0.3.3.0 (2019-11-27)</a></h3>
+<div class="section" id="section-8">
+<h3><a class="toc-backref" href="#toc-entry-11">12.0.3.3.0 (2019-11-27)</a></h3>
 <p>New features:</p>
 <ul class="simple">
 <li>Add comment on Reviews Table.</li>
 <li>Approve by sequence.</li>
 </ul>
 </div>
-<div class="section" id="section-8">
-<h3><a class="toc-backref" href="#toc-entry-11">12.0.3.2.1 (2019-11-26)</a></h3>
+<div class="section" id="section-9">
+<h3><a class="toc-backref" href="#toc-entry-12">12.0.3.2.1 (2019-11-26)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Remove message_subscribe_users</li>
 </ul>
 </div>
-<div class="section" id="section-9">
-<h3><a class="toc-backref" href="#toc-entry-12">12.0.3.2.0 (2019-11-25)</a></h3>
+<div class="section" id="section-10">
+<h3><a class="toc-backref" href="#toc-entry-13">12.0.3.2.0 (2019-11-25)</a></h3>
 <p>New features:</p>
 <ul class="simple">
 <li>Notify reviewers</li>
 </ul>
 </div>
-<div class="section" id="section-10">
-<h3><a class="toc-backref" href="#toc-entry-13">12.0.3.1.0 (2019-07-08)</a></h3>
+<div class="section" id="section-11">
+<h3><a class="toc-backref" href="#toc-entry-14">12.0.3.1.0 (2019-07-08)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Singleton error</li>
 </ul>
 </div>
-<div class="section" id="section-11">
-<h3><a class="toc-backref" href="#toc-entry-14">12.0.3.0.0 (2019-12-02)</a></h3>
+<div class="section" id="section-12">
+<h3><a class="toc-backref" href="#toc-entry-15">12.0.3.0.0 (2019-12-02)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Edit Reviews Table</li>
 </ul>
 </div>
-<div class="section" id="section-12">
-<h3><a class="toc-backref" href="#toc-entry-15">12.0.2.1.0 (2019-05-29)</a></h3>
+<div class="section" id="section-13">
+<h3><a class="toc-backref" href="#toc-entry-16">12.0.2.1.0 (2019-05-29)</a></h3>
 <p>Fixes:</p>
 <ul class="simple">
 <li>Edit drop-down style width and position</li>
 </ul>
 </div>
-<div class="section" id="section-13">
-<h3><a class="toc-backref" href="#toc-entry-16">12.0.2.0.0 (2019-05-28)</a></h3>
+<div class="section" id="section-14">
+<h3><a class="toc-backref" href="#toc-entry-17">12.0.2.0.0 (2019-05-28)</a></h3>
 <p>New features:</p>
 <ul class="simple">
 <li>Pass parameters as functions.</li>
 <li>Add Systray.</li>
 </ul>
 </div>
-<div class="section" id="section-14">
-<h3><a class="toc-backref" href="#toc-entry-17">12.0.1.0.0 (2019-02-18)</a></h3>
+<div class="section" id="section-15">
+<h3><a class="toc-backref" href="#toc-entry-18">12.0.1.0.0 (2019-02-18)</a></h3>
 <p>Migrated to Odoo 12.</p>
 </div>
-<div class="section" id="section-15">
-<h3><a class="toc-backref" href="#toc-entry-18">11.0.1.0.0 (2018-05-09)</a></h3>
+<div class="section" id="section-16">
+<h3><a class="toc-backref" href="#toc-entry-19">11.0.1.0.0 (2018-05-09)</a></h3>
 <p>Migrated to Odoo 11.</p>
 </div>
-<div class="section" id="section-16">
-<h3><a class="toc-backref" href="#toc-entry-19">10.0.1.0.0 (2018-03-26)</a></h3>
+<div class="section" id="section-17">
+<h3><a class="toc-backref" href="#toc-entry-20">10.0.1.0.0 (2018-03-26)</a></h3>
 <p>Migrated to Odoo 10.</p>
 </div>
-<div class="section" id="section-17">
-<h3><a class="toc-backref" href="#toc-entry-20">9.0.1.0.0 (2017-12-02)</a></h3>
+<div class="section" id="section-18">
+<h3><a class="toc-backref" href="#toc-entry-21">9.0.1.0.0 (2017-12-02)</a></h3>
 <p>First version.</p>
 </div>
 </div>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#toc-entry-21">Bug Tracker</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-22">Bug Tracker</a></h2>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/tier-validation/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -635,15 +657,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#toc-entry-22">Credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-23">Credits</a></h2>
 <div class="section" id="authors">
-<h3><a class="toc-backref" href="#toc-entry-23">Authors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-24">Authors</a></h3>
 <ul class="simple">
 <li>ForgeFlow</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h3><a class="toc-backref" href="#toc-entry-24">Contributors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-25">Contributors</a></h3>
 <ul class="simple">
 <li>Lois Rilo &lt;<a class="reference external" href="mailto:lois.rilo&#64;forgeflow.com">lois.rilo&#64;forgeflow.com</a>&gt;</li>
 <li>Naglis Jonaitis &lt;<a class="reference external" href="mailto:naglis&#64;versada.eu">naglis&#64;versada.eu</a>&gt;</li>
@@ -668,10 +690,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="other-credits">
-<h3><a class="toc-backref" href="#toc-entry-25">Other credits</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-26">Other credits</a></h3>
 </div>
 <div class="section" id="maintainers">
-<h3><a class="toc-backref" href="#toc-entry-26">Maintainers</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-27">Maintainers</a></h3>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -1454,6 +1454,127 @@ class TierTierValidation(CommonTierValidation):
         # Review_ids should not be copied when duplicating a user
         self.assertFalse(new_user.review_ids.ids)
 
+    def test_36_tier_summary_is_human_readable(self):
+        """The computed summary names the document, the condition and the
+        reviewer in plain language."""
+        summary = self.definition_1.tier_summary
+        self.assertTrue(summary)
+        self.assertIn(self.definition_1.model_id.name, summary)
+        self.assertIn(self.test_user_1.display_name, summary)
+        self.assertIn("Tier", summary)
+        # The condition is rendered with the human field label, not the
+        # technical name -- that is the whole point of the summary.
+        test_field_label = self.test_model._fields["test_field"].string
+        self.assertIn(test_field_label, summary)
+
+    def test_37_invalid_definition_domain_is_blocked(self):
+        """A malformed domain is rejected at save time (not only later at
+        request_validation)."""
+        with self.assertRaises(ValidationError):
+            self.tier_def_obj.create(
+                {
+                    "model_id": self.tester_model.id,
+                    "review_type": "individual",
+                    "reviewer_id": self.test_user_1.id,
+                    "definition_domain": "this is not a domain",
+                }
+            )
+
+    def test_38_empty_domain_onchange_warns(self):
+        definition = self.tier_def_obj.new(
+            {"model_id": self.tester_model.id, "definition_domain": ""}
+        )
+        res = definition._onchange_definition_domain_warn_empty()
+        self.assertIn("warning", res)
+
+    def test_39_form_requires_reviewer_for_its_type(self):
+        """The matching reviewer is required in the form when a review type
+        is chosen, but plain create() stays unconstrained so bridge
+        modules can still create a definition and set the reviewer later."""
+        # Form save without the reviewer for the chosen type must fail.
+        form = Form(self.tier_def_obj)
+        form.model_id = self.tester_model
+        form.review_type = "individual"
+        with self.assertRaises(AssertionError):
+            form.save()
+        # Programmatic create stays allowed (no reviewer yet).
+        definition = self.tier_def_obj.create(
+            {"model_id": self.tester_model.id, "review_type": "individual"}
+        )
+        self.assertTrue(definition.id)
+
+    def test_40_summary_helpers_cover_all_branches(self):
+        """Exercise every branch of the summary / lint helpers."""
+        # _describe_domain: every rendering path (use new() so the domain
+        # constraint does not block the intentionally odd values).
+        cases = {
+            "": "all records",
+            "[]": "all records",
+            "garbage": "where",
+            "1": "all records",
+            "['&']": "where",
+            "[('test_field', '>', 1.0)]": "Test Field",
+            "[('unknown_field', '=', 1)]": "unknown_field",
+        }
+        for raw, expected in cases.items():
+            definition = self.tier_def_obj.new(
+                {"model_id": self.tester_model.id, "definition_domain": raw}
+            )
+            self.assertIn(expected, definition._describe_domain())
+
+        # _describe_reviewer + summary for the group review type.
+        group_def = self.tier_def_obj.create(
+            {
+                "model_id": self.tester_model.id,
+                "review_type": "group",
+                "reviewer_group_id": self.test_group.id,
+                "definition_domain": "[]",
+            }
+        )
+        self.assertIn(self.test_group.display_name, group_def.tier_summary)
+
+        # _describe_reviewer + summary for the field review type.
+        user_field = self.env["ir.model.fields"].search(
+            [("model", "=", "tier.validation.tester"), ("name", "=", "user_id")],
+            limit=1,
+        )
+        field_def = self.tier_def_obj.create(
+            {
+                "model_id": self.tester_model.id,
+                "review_type": "field",
+                "reviewer_field_id": user_field.id,
+                "definition_domain": "[]",
+            }
+        )
+        self.assertIn(
+            user_field.field_description or user_field.name,
+            field_def.tier_summary,
+        )
+
+        # _compute_tier_summary: definition without a model -> empty summary.
+        no_model = self.tier_def_obj.create({"name": "No model rule"})
+        self.assertEqual(no_model.tier_summary, "")
+
+        # _check_definition_domain: a parseable but non-list value is rejected.
+        with self.assertRaises(ValidationError):
+            self.tier_def_obj.create(
+                {
+                    "model_id": self.tester_model.id,
+                    "review_type": "individual",
+                    "reviewer_id": self.test_user_1.id,
+                    "definition_domain": "1",
+                }
+            )
+
+        # Onchange "no warning" path for a non-empty domain.
+        ok_domain = self.tier_def_obj.new(
+            {
+                "model_id": self.tester_model.id,
+                "definition_domain": "[('test_field', '>', 1.0)]",
+            }
+        )
+        self.assertFalse(ok_domain._onchange_definition_domain_warn_empty())
+
 
 @tagged("at_install")
 class TierTierValidationView(CommonTierValidation):

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -1599,6 +1599,127 @@ class TierTierValidation(CommonTierValidation):
         # Review_ids should not be copied when duplicating a user
         self.assertFalse(new_user.review_ids.ids)
 
+    def test_36_tier_summary_is_human_readable(self):
+        """The computed summary names the document, the condition and the
+        reviewer in plain language."""
+        summary = self.definition_1.tier_summary
+        self.assertTrue(summary)
+        self.assertIn(self.definition_1.model_id.name, summary)
+        self.assertIn(self.test_user_1.display_name, summary)
+        self.assertIn("Tier", summary)
+        # The condition is rendered with the human field label, not the
+        # technical name -- that is the whole point of the summary.
+        test_field_label = self.test_model._fields["test_field"].string
+        self.assertIn(test_field_label, summary)
+
+    def test_37_invalid_definition_domain_is_blocked(self):
+        """A malformed domain is rejected at save time (not only later at
+        request_validation)."""
+        with self.assertRaises(ValidationError):
+            self.tier_def_obj.create(
+                {
+                    "model_id": self.tester_model.id,
+                    "review_type": "individual",
+                    "reviewer_id": self.test_user_1.id,
+                    "definition_domain": "this is not a domain",
+                }
+            )
+
+    def test_38_empty_domain_onchange_warns(self):
+        definition = self.tier_def_obj.new(
+            {"model_id": self.tester_model.id, "definition_domain": ""}
+        )
+        res = definition._onchange_definition_domain_warn_empty()
+        self.assertIn("warning", res)
+
+    def test_39_form_requires_reviewer_for_its_type(self):
+        """The matching reviewer is required in the form when a review type
+        is chosen, but plain create() stays unconstrained so bridge
+        modules can still create a definition and set the reviewer later."""
+        # Form save without the reviewer for the chosen type must fail.
+        form = Form(self.tier_def_obj)
+        form.model_id = self.tester_model
+        form.review_type = "individual"
+        with self.assertRaises(AssertionError):
+            form.save()
+        # Programmatic create stays allowed (no reviewer yet).
+        definition = self.tier_def_obj.create(
+            {"model_id": self.tester_model.id, "review_type": "individual"}
+        )
+        self.assertTrue(definition.id)
+
+    def test_40_summary_helpers_cover_all_branches(self):
+        """Exercise every branch of the summary / lint helpers."""
+        # _describe_domain: every rendering path (use new() so the domain
+        # constraint does not block the intentionally odd values).
+        cases = {
+            "": "all records",
+            "[]": "all records",
+            "garbage": "where",
+            "1": "all records",
+            "['&']": "where",
+            "[('test_field', '>', 1.0)]": "Test Field",
+            "[('unknown_field', '=', 1)]": "unknown_field",
+        }
+        for raw, expected in cases.items():
+            definition = self.tier_def_obj.new(
+                {"model_id": self.tester_model.id, "definition_domain": raw}
+            )
+            self.assertIn(expected, definition._describe_domain())
+
+        # _describe_reviewer + summary for the group review type.
+        group_def = self.tier_def_obj.create(
+            {
+                "model_id": self.tester_model.id,
+                "review_type": "group",
+                "reviewer_group_id": self.test_group.id,
+                "definition_domain": "[]",
+            }
+        )
+        self.assertIn(self.test_group.display_name, group_def.tier_summary)
+
+        # _describe_reviewer + summary for the field review type.
+        user_field = self.env["ir.model.fields"].search(
+            [("model", "=", "tier.validation.tester"), ("name", "=", "user_id")],
+            limit=1,
+        )
+        field_def = self.tier_def_obj.create(
+            {
+                "model_id": self.tester_model.id,
+                "review_type": "field",
+                "reviewer_field_id": user_field.id,
+                "definition_domain": "[]",
+            }
+        )
+        self.assertIn(
+            user_field.field_description or user_field.name,
+            field_def.tier_summary,
+        )
+
+        # _compute_tier_summary: definition without a model -> empty summary.
+        no_model = self.tier_def_obj.create({"name": "No model rule"})
+        self.assertEqual(no_model.tier_summary, "")
+
+        # _check_definition_domain: a parseable but non-list value is rejected.
+        with self.assertRaises(ValidationError):
+            self.tier_def_obj.create(
+                {
+                    "model_id": self.tester_model.id,
+                    "review_type": "individual",
+                    "reviewer_id": self.test_user_1.id,
+                    "definition_domain": "1",
+                }
+            )
+
+        # Onchange "no warning" path for a non-empty domain.
+        ok_domain = self.tier_def_obj.new(
+            {
+                "model_id": self.tester_model.id,
+                "definition_domain": "[('test_field', '>', 1.0)]",
+            }
+        )
+        self.assertFalse(ok_domain._onchange_definition_domain_warn_empty())
+
 
 @tagged("at_install")
 class TierTierValidationView(CommonTierValidation):

--- a/base_tier_validation/views/tier_definition_view.xml
+++ b/base_tier_validation/views/tier_definition_view.xml
@@ -10,6 +10,7 @@
                 <field name="sequence" widget="handle" />
                 <field name="model_id" />
                 <field name="name" />
+                <field name="tier_summary" optional="show" />
                 <field name="review_type" />
                 <field name="reviewer_id" />
                 <field name="reviewer_group_id" />
@@ -20,7 +21,7 @@
                 <field
                     name="company_id"
                     groups="base.group_multi_company"
-                    optional="hide"
+                    optional="show"
                 />
                 <field name="active" />
             </list>
@@ -49,6 +50,13 @@
                             />
                         </h1>
                     </div>
+                    <div
+                        class="alert alert-info"
+                        role="status"
+                        invisible="not tier_summary"
+                    >
+                        <field name="tier_summary" />
+                    </div>
                     <group>
                         <group name="left">
                             <field name="model_id" options="{'no_create': True}" />
@@ -58,14 +66,17 @@
                             <field
                                 name="reviewer_id"
                                 invisible="review_type != 'individual'"
+                                required="review_type == 'individual'"
                             />
                             <field
                                 name="reviewer_group_id"
                                 invisible="review_type != 'group'"
+                                required="review_type == 'group'"
                             />
                             <field
                                 name="reviewer_field_id"
                                 invisible="review_type != 'field'"
+                                required="review_type == 'field'"
                                 options="{'no_create': True}"
                             />
                         </group>
@@ -142,7 +153,7 @@
                 <group>
                     <filter
                         string="Model"
-                        name="model_id"
+                        name="group_by_model"
                         domain="[]"
                         context="{'group_by':'model_id'}"
                     />
@@ -155,7 +166,9 @@
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">tier.definition</field>
         <field name="view_mode">list,form</field>
-        <field name="context">{'search_default_all': 1}</field>
+        <field
+            name="context"
+        >{'search_default_all': 1, 'search_default_group_by_model': 1}</field>
     </record>
     <menuitem
         id="menu_tier_confirmation"

--- a/base_tier_validation/views/tier_definition_view.xml
+++ b/base_tier_validation/views/tier_definition_view.xml
@@ -10,6 +10,7 @@
                 <field name="sequence" widget="handle" />
                 <field name="model_id" />
                 <field name="name" />
+                <field name="tier_summary" optional="show" />
                 <field name="review_type" />
                 <field name="reviewer_id" />
                 <field name="reviewer_group_id" />
@@ -20,7 +21,7 @@
                 <field
                     name="company_id"
                     groups="base.group_multi_company"
-                    optional="hide"
+                    optional="show"
                 />
                 <field name="active" />
             </list>
@@ -49,6 +50,13 @@
                             />
                         </h1>
                     </div>
+                    <div
+                        class="alert alert-info"
+                        role="status"
+                        invisible="not tier_summary"
+                    >
+                        <field name="tier_summary" />
+                    </div>
                     <group>
                         <group name="left">
                             <field name="model_id" options="{'no_create': True}" />
@@ -58,14 +66,17 @@
                             <field
                                 name="reviewer_id"
                                 invisible="review_type != 'individual'"
+                                required="review_type == 'individual'"
                             />
                             <field
                                 name="reviewer_group_id"
                                 invisible="review_type != 'group'"
+                                required="review_type == 'group'"
                             />
                             <field
                                 name="reviewer_field_id"
                                 invisible="review_type != 'field'"
+                                required="review_type == 'field'"
                                 options="{'no_create': True}"
                             />
                         </group>
@@ -146,7 +157,7 @@
                 <group>
                     <filter
                         string="Model"
-                        name="model_id"
+                        name="group_by_model"
                         domain="[]"
                         context="{'group_by':'model_id'}"
                     />
@@ -159,7 +170,9 @@
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">tier.definition</field>
         <field name="view_mode">list,form</field>
-        <field name="context">{'search_default_all': 1}</field>
+        <field
+            name="context"
+        >{'search_default_all': 1, 'search_default_group_by_model': 1}</field>
     </record>
     <menuitem
         id="menu_tier_confirmation"


### PR DESCRIPTION
## Why

Creating a `tier.definition` is hard for non-technical users: a raw
Odoo domain (`[('amount_total','>',1000)]`), technical model/field
names, and three interacting knobs (`sequence`, `approve_sequence`,
`approve_sequence_bypass`) with nothing showing how multiple rules
combine into an ordered chain. There is also no human-readable summary
anywhere, and a bad domain only blows up later at
`request_validation`.



## What

- **Plain-language Summary** (`tier_summary`, computed): a one-sentence
  description of the rule shown as an info banner on the form and as a
  list column, e.g. *"Tier 30 — Journal Entry where amount_total >
  1000: validated by Specific user John Doe (in sequence)"*. Domain
  rendering is best-effort and never raises (falls back to the raw
  string).
- **Inline help** on the model, filter, reviewer-field, sequence and
  approval fields, including a concrete domain example.
- **Per-model overview**: the Tier Definition list now opens grouped
  by document type, in sequence order (`_order = "sequence, id"`), so
  the full ordered tier chain per model is visible at a glance.
- **Self-check**: a malformed filter is rejected at save time with a
  clear `ValidationError` (consistent with the existing `literal_eval`
  in `evaluate_tier`). Non-blocking onchange warnings fire when a rule
  has no filter, or no reviewer set for the chosen *Validated by*.

### Design note

The "reviewer not set" check is an **onchange warning, not a
constraint**, on purpose: definitions are legitimately created
incomplete -- programmatically and by bridge modules (e.g.
`account_move_tier_validation` creates a definition then sets the
reviewer later). A hard constraint would regress those flows and
existing tests. Only the domain-parse check is hard, because the
runtime already requires the domain to be `literal_eval`-able.

## Tests

`test_36`–`test_39`: summary is human-readable (names model, condition,
reviewer); malformed domain blocked at create; empty-domain and
missing-reviewer onchanges return warnings.

## Scope

19.0 only. No `__manifest__.py` bump (ocabot bumps on merge).