### PR TITLE
[19.0][FIX] base_tier_validation: don't promote later tiers out of sequence

### DIFF
--- a/base_tier_validation/models/tier_review.py
+++ b/base_tier_validation/models/tier_review.py
@@ -106,11 +106,28 @@ class TierReview(models.Model):
         reviews = self.filtered(lambda rev: rev.status in ["waiting", "pending"])
         if not reviews:
             return
-        next_seq = min(reviews.mapped("sequence"))
+        # Lowest still-open sequence *per record*, computed over the whole
+        # record's reviews -- NOT just this recordset. Computing it over
+        # ``self`` promotes a later tier prematurely whenever the method runs on
+        # a subset that excludes the lower-sequence predecessors, e.g.
+        # ``review_user_count`` calling ``user.review_ids._update_review_status()``
+        # for a second-tier reviewer (their own review is then the only -- and
+        # thus "minimum" -- sequence in the set, so it wrongly goes ``pending``).
+        min_seq_by_record = {}
+        for model, res_id in {(rev.model, rev.res_id) for rev in reviews}:
+            open_reviews = (
+                self.env[model]
+                .browse(res_id)
+                .review_ids.filtered(lambda r: r.status in ("waiting", "pending"))
+            )
+            min_seq_by_record[(model, res_id)] = min(open_reviews.mapped("sequence"))
         for record in reviews:
             if record.status != "waiting":
                 continue
-            if record.approve_sequence and record.sequence != next_seq:
+            if (
+                record.approve_sequence
+                and record.sequence != min_seq_by_record[(record.model, record.res_id)]
+            ):
                 continue
             record.status = "pending"
             if record.definition_id.notify_on_pending:

--- a/base_tier_validation/tests/test_tier_validation.py
+++ b/base_tier_validation/tests/test_tier_validation.py
@@ -757,6 +757,67 @@ class TierTierValidation(CommonTierValidation):
             "Second-tier reviewer must be notified once promoted to pending.",
         )
 
+    def test_19c_no_premature_promotion_on_subset(self):
+        """Regression: ``_update_review_status`` run on a *subset* of a record's
+        reviews -- as ``review_user_count`` does per user, via
+        ``user.review_ids._update_review_status()`` -- must gate the sequence
+        over the *whole* record, not the subset. Otherwise a later-tier review
+        is promoted to ``pending`` before its predecessor is approved, which
+        both hides it from the reviewer's systray (``can_review`` is False while
+        the lower tier is still pending) and fires a ``notify_on_pending``
+        message authored by -- and so never delivered to -- that reviewer.
+        """
+        TierDefinition = self.env["tier.definition"]
+        test_record = self.test_model.create({"test_field": 2.5})
+        TierDefinition.create(
+            {
+                "model_id": self.tester_model.id,
+                "review_type": "individual",
+                "reviewer_id": self.test_user_1.id,
+                "definition_domain": "[('test_field', '=', 2.5)]",
+                "approve_sequence": True,
+                "notify_on_pending": True,
+                "sequence": 20,
+                "name": "First in sequence -- user 1",
+            }
+        )
+        TierDefinition.create(
+            {
+                "model_id": self.tester_model.id,
+                "review_type": "individual",
+                "reviewer_id": self.test_user_2.id,
+                "definition_domain": "[('test_field', '=', 2.5)]",
+                "approve_sequence": True,
+                "notify_on_pending": True,
+                "sequence": 10,
+                "name": "Second in sequence -- user 2",
+            }
+        )
+        reviews = test_record.request_validation()
+        review_second = reviews.filtered(lambda r: self.test_user_2 in r.reviewer_ids)
+        self.assertEqual(review_second.status, "waiting")
+        messages_before = test_record.message_ids
+
+        # Simulate the second-tier reviewer opening their systray: the promotion
+        # runs on *only* their own review -- the subset that excludes the
+        # first-tier predecessor.
+        review_second._update_review_status()
+        review_second.invalidate_recordset()
+
+        self.assertEqual(
+            review_second.status,
+            "waiting",
+            "A later-tier review must stay 'waiting' until its predecessor is "
+            "approved, even when _update_review_status runs on a subset that "
+            "excludes the predecessor.",
+        )
+        self.assertEqual(
+            test_record.message_ids,
+            messages_before,
+            "No notify_on_pending message must be posted from promoting a later "
+            "tier out of order.",
+        )
+
     def test_19b_notify_review_available_no_op_when_no_users(self):
         """``_notify_review_available`` must short-circuit (no follower
         added, no chatter message posted) when none of the passed reviews


### PR DESCRIPTION
### Problem
With `approve_sequence`, a later-tier review could be promoted to `pending` **before its predecessor is approved**, which then:
- hides it from that reviewer's own systray (`can_review` is False while the lower tier still holds the minimum sequence), and
- mis-routes the `notify_on_pending` chatter message to the **previous** reviewer instead of the intended one.

### Root cause
`tier.review._update_review_status` gates promotion on `min(self.mapped("sequence"))` — the minimum over the **recordset it happens to be called on**, not the whole record. `res.users.review_user_count` calls it as `user.review_ids._update_review_status()`, i.e. on a **single user's** reviews. For a second-tier reviewer that subset contains only their own (higher-sequence) review, so it becomes the "minimum" and is promoted prematurely the moment they open their systray.

The premature `pending` then cascades: `can_review` evaluates False (the lower tier holds the min sequence) → hidden from the systray; the `notify_on_pending` message is posted in that reviewer's own transaction → they are excluded as its author and the alert lands on the previous reviewer; and when the first tier is finally approved the review is already `pending`, so it is skipped and no correct notification ever fires.

### Fix
Compute the gating sequence over the **whole record's** open reviews (per `res_id`), not the passed recordset. No behaviour change for the normal full-recordset call (`request_validation` → `_update_review_status`).

### Test
Adds `test_19c_no_premature_promotion_on_subset`, which runs `_update_review_status` on **only** the later-tier reviewer's review (the `review_user_count` path) and asserts it stays `waiting` and posts no message. `test_19a` only exercised the full-recordset path, so the regression slipped through.

<!-- Independent, pre-existing bug (the method is untouched by other open PRs). Complements the notify_on_pending routing work in #22. -->