### PR TITLE
[FIX] base_tier_validation: prevent copy of review_ids on duplication

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -41,6 +41,7 @@ class TierValidation(models.AbstractModel):
         string="Validations",
         domain=lambda self: [("model", "=", self._name)],
         bypass_search_access=True,
+        copy=False,
     )
     to_validate_message = fields.Html(compute="_compute_to_validate_message")
     validated_message = fields.Html(compute="_compute_validated_message")


### PR DESCRIPTION
## Summary

Add `copy=False` to the `review_ids` `One2many` field in `TierValidationMixin`.

### Root cause

The `review_ids` field is declared without `copy=False`. When a user
duplicates any record that uses the `TierValidationMixin` (e.g. a posted
vendor bill after validation), the ORM silently clones every `tier.review`
row onto the new record.

Stored compute fields that depend on `review_ids` are re-evaluated inside
`create()` against this partially-initialised state. In models that run
non-trivial logic during their own stored compute fields this can raise:

```
TypeError: argument of type 'bool' is not iterable
```

(Seen in `account.move._compute_needed_terms` when `base_tier_validation`
is combined with `account_move_tier_validation`.)

More broadly, a duplicated record should begin as a clean, unvalidated draft
with no inherited approval history — the current behaviour is almost never
what users expect.

### Fix

One line: add `copy=False` to the `review_ids` field declaration.

```python
review_ids = fields.One2many(
    ...
    copy=False,
)
```

This is equivalent to what `res.partner` does for `bank_ids`, and follows
Odoo's own pattern for relationship fields that should not be inherited by
duplicates.

### Testing

Tested by duplicating a validated record (`account.move` with
`base_tier_validation`) and confirming:

1. The duplicate is created without error.
2. The duplicate has no `review_ids`.
3. Calling `request_validation()` on the duplicate works normally.